### PR TITLE
Fix setting sysprocattr correctly based on command

### DIFF
--- a/internal/osexec/osexec.go
+++ b/internal/osexec/osexec.go
@@ -29,15 +29,17 @@ func Execute(cmd string, args []string, env []string, logger log.Logger) ([]byte
 		execCmd.Env = append(os.Environ(), env...)
 	}
 
-	// Start child process in its own process group so that interrupt signal will
-	// not stop the command
-	execCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-
-	// Attach a separate terminal less session to the subprocess
-	// This is to avoid prompting for password when we run command with sudo
-	// Ref: https://stackoverflow.com/questions/13432947/exec-external-program-script-and-detect-if-it-requests-user-input
+	// According to setpgid docs (https://man7.org/linux/man-pages/man2/setpgid.2.html)
+	// we cannot use setpgid and setsid at the same time
 	if cmd == sudoCmd {
-		execCmd.SysProcAttr.Setsid = true
+		// Attach a separate terminal less session to the subprocess
+		// This is to avoid prompting for password when we run command with sudo
+		// Ref: https://stackoverflow.com/questions/13432947/exec-external-program-script-and-detect-if-it-requests-user-input
+		execCmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	} else {
+		// Start child process in its own process group so that interrupt signal will
+		// not stop the command
+		execCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	}
 
 	// Execute command
@@ -67,9 +69,18 @@ func ExecuteAs(cmd string, args []string, uid int, gid int, env []string, logger
 		gidInt32 = uint32(gid)
 	}
 
-	// Start child process in its own process group so that interrupt signal will
-	// not stop the command
-	execCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	// According to setpgid docs (https://man7.org/linux/man-pages/man2/setpgid.2.html)
+	// we cannot use setpgid and setsid at the same time
+	if cmd == sudoCmd {
+		// Attach a separate terminal less session to the subprocess
+		// This is to avoid prompting for password when we run command with sudo
+		// Ref: https://stackoverflow.com/questions/13432947/exec-external-program-script-and-detect-if-it-requests-user-input
+		execCmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	} else {
+		// Start child process in its own process group so that interrupt signal will
+		// not stop the command
+		execCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	}
 
 	// Set uid and gid for process
 	execCmd.SysProcAttr.Credential = &syscall.Credential{Uid: uidInt32, Gid: gidInt32}
@@ -100,15 +111,17 @@ func ExecuteContext(ctx context.Context, cmd string, args []string, env []string
 		execCmd.Env = append(os.Environ(), env...)
 	}
 
-	// Start child process in its own process group so that interrupt signal will
-	// not stop the command
-	execCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-
-	// Attach a separate terminal less session to the subprocess
-	// This is to avoid prompting for password when we run command with sudo
-	// Ref: https://stackoverflow.com/questions/13432947/exec-external-program-script-and-detect-if-it-requests-user-input
+	// According to setpgid docs (https://man7.org/linux/man-pages/man2/setpgid.2.html)
+	// we cannot use setpgid and setsid at the same time
 	if cmd == sudoCmd {
-		execCmd.SysProcAttr.Setsid = true
+		// Attach a separate terminal less session to the subprocess
+		// This is to avoid prompting for password when we run command with sudo
+		// Ref: https://stackoverflow.com/questions/13432947/exec-external-program-script-and-detect-if-it-requests-user-input
+		execCmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	} else {
+		// Start child process in its own process group so that interrupt signal will
+		// not stop the command
+		execCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	}
 
 	// Execute command
@@ -138,9 +151,18 @@ func ExecuteAsContext(ctx context.Context, cmd string, args []string, uid int, g
 		gidInt32 = uint32(gid)
 	}
 
-	// Start child process in its own process group so that interrupt signal will
-	// not stop the command
-	execCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	// According to setpgid docs (https://man7.org/linux/man-pages/man2/setpgid.2.html)
+	// we cannot use setpgid and setsid at the same time
+	if cmd == sudoCmd {
+		// Attach a separate terminal less session to the subprocess
+		// This is to avoid prompting for password when we run command with sudo
+		// Ref: https://stackoverflow.com/questions/13432947/exec-external-program-script-and-detect-if-it-requests-user-input
+		execCmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	} else {
+		// Start child process in its own process group so that interrupt signal will
+		// not stop the command
+		execCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	}
 
 	// Set uid and gid for process
 	execCmd.SysProcAttr.Credential = &syscall.Credential{Uid: uidInt32, Gid: gidInt32}
@@ -180,15 +202,17 @@ func ExecuteWithTimeout(cmd string, args []string, timeout int, env []string, lo
 		execCmd.Env = append(os.Environ(), env...)
 	}
 
-	// Start child process in its own process group so that interrupt signal will
-	// not stop the command
-	execCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-
-	// Attach a separate terminal less session to the subprocess
-	// This is to avoid prompting for password when we run command with sudo
-	// Ref: https://stackoverflow.com/questions/13432947/exec-external-program-script-and-detect-if-it-requests-user-input
+	// According to setpgid docs (https://man7.org/linux/man-pages/man2/setpgid.2.html)
+	// we cannot use setpgid and setsid at the same time
 	if cmd == sudoCmd {
-		execCmd.SysProcAttr.Setsid = true
+		// Attach a separate terminal less session to the subprocess
+		// This is to avoid prompting for password when we run command with sudo
+		// Ref: https://stackoverflow.com/questions/13432947/exec-external-program-script-and-detect-if-it-requests-user-input
+		execCmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	} else {
+		// Start child process in its own process group so that interrupt signal will
+		// not stop the command
+		execCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	}
 
 	// The signal to send to the children when parent receives a kill signal
@@ -242,9 +266,18 @@ func ExecuteAsWithTimeout(
 		gidInt32 = uint32(gid)
 	}
 
-	// Start child process in its own process group so that interrupt signal will
-	// not stop the command
-	execCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	// According to setpgid docs (https://man7.org/linux/man-pages/man2/setpgid.2.html)
+	// we cannot use setpgid and setsid at the same time
+	if cmd == sudoCmd {
+		// Attach a separate terminal less session to the subprocess
+		// This is to avoid prompting for password when we run command with sudo
+		// Ref: https://stackoverflow.com/questions/13432947/exec-external-program-script-and-detect-if-it-requests-user-input
+		execCmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	} else {
+		// Start child process in its own process group so that interrupt signal will
+		// not stop the command
+		execCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	}
 
 	// Set uid and gid for process
 	execCmd.SysProcAttr.Credential = &syscall.Credential{Uid: uidInt32, Gid: gidInt32}

--- a/pkg/api/http/docs/docs.go
+++ b/pkg/api/http/docs/docs.go
@@ -15,8 +15,8 @@ const docTemplate = `{
             "email": "mahendra.paipuri@gmail.com"
         },
         "license": {
-            "name": "BSD-3-Clause license",
-            "url": "https://opensource.org/license/bsd-3-clause"
+            "name": "GPL-3.0 license",
+            "url": "https://www.gnu.org/licenses/gpl-3.0.en.html"
         },
         "version": "{{.Version}}"
     },

--- a/pkg/api/http/docs/swagger.json
+++ b/pkg/api/http/docs/swagger.json
@@ -9,8 +9,8 @@
             "email": "mahendra.paipuri@gmail.com"
         },
         "license": {
-            "name": "BSD-3-Clause license",
-            "url": "https://opensource.org/license/bsd-3-clause"
+            "name": "GPL-3.0 license",
+            "url": "https://www.gnu.org/licenses/gpl-3.0.en.html"
         },
         "version": "1.0"
     },

--- a/pkg/api/http/docs/swagger.yaml
+++ b/pkg/api/http/docs/swagger.yaml
@@ -453,8 +453,8 @@ info:
 
     Timestamps must be specified in milliseconds, unless otherwise specified.
   license:
-    name: BSD-3-Clause license
-    url: https://opensource.org/license/bsd-3-clause
+    name: GPL-3.0 license
+    url: https://www.gnu.org/licenses/gpl-3.0.en.html
   title: CEEMS API
   version: "1.0"
 paths:

--- a/pkg/api/http/server.go
+++ b/pkg/api/http/server.go
@@ -247,7 +247,7 @@ func New(c *Config) (*CEEMSServer, func(), error) {
 	)).Methods(http.MethodGet)
 
 	// Open DB connection
-	dsn := fmt.Sprintf("file:%s?%s", filepath.Join(c.DB.Data.Path, base.CEEMSDBName), "_mutex=no&mode=ro")
+	dsn := fmt.Sprintf("file:%s?%s", filepath.Join(c.DB.Data.Path, base.CEEMSDBName), "_mutex=no&mode=ro&_busy_timeout=5000")
 	if server.db, err = sql.Open(sqlite3.DriverName, dsn); err != nil {
 		return nil, func() {}, fmt.Errorf("failed to open DB: %w", err)
 	}
@@ -299,8 +299,8 @@ func New(c *Config) (*CEEMSServer, func(), error) {
 //	@contact.url				https://github.com/mahendrapaipuri/ceems/issues
 //	@contact.email				mahendra.paipuri@gmail.com
 //
-//	@license.name				BSD-3-Clause license
-//	@license.url				https://opensource.org/license/bsd-3-clause
+//	@license.name				GPL-3.0 license
+//	@license.url				https://www.gnu.org/licenses/gpl-3.0.en.html
 //
 //	@securityDefinitions.basic	BasicAuth
 //

--- a/pkg/lb/frontend/frontend.go
+++ b/pkg/lb/frontend/frontend.go
@@ -96,7 +96,9 @@ func New(c *Config) (LoadBalancer, error) {
 		// Set DB pointer only if file exists. Else sql.Open will create an empty
 		// file as if exists already
 		if _, err := os.Stat(dbAbsPath); err == nil {
-			if db, err = sql.Open("sqlite3", dbAbsPath); err != nil {
+			dsn := fmt.Sprintf("file:%s?%s", dbAbsPath, "_mutex=no&mode=ro&_busy_timeout=5000")
+
+			if db, err = sql.Open("sqlite3", dsn); err != nil {
 				return nil, err
 			}
 		}

--- a/website/docs/installation/prerequisites.md
+++ b/website/docs/installation/prerequisites.md
@@ -4,16 +4,10 @@ sidebar_position: 1
 
 # Prerequisites
 
-There are no direct dependencies that are needed to install CEEMS stack. However, CEEMS 
-is designed to work with a TSDB and hence, [Prometheus](https://prometheus.io/) or 
-[Victoria Metrics](https://victoriametrics.com/) 
-must be available to store the scrapped metrics. 
+There are no direct dependencies that are needed to install CEEMS stack. However, CEEMS
+is designed to work with a TSDB and hence, [Prometheus](https://prometheus.io/) or
+[Victoria Metrics](https://victoriametrics.com/)
+must be available to store the scrapped metrics.
 
-Installation of Prometheus can be found in its [docs](https://prometheus.io/download/) 
-and it is out of current scope. 
-
-CEEMS API server uses [SQLite](https://www.sqlite.org/) as DB engine and it it 
-shipped by default in most of the OS distributions. CEEMS uses 
-[JSON functions](https://www.sqlite.org/json1.html) of SQLite which have been 
-integrated by default from version `3.38.0`. Thus, SQLite `>=3.38.0` is a required 
-dependency for CEEMS to work properly.
+Installation of Prometheus can be found in its [docs](https://prometheus.io/download/)
+and it is out of current scope.


### PR DESCRIPTION
* Setsid and Setpgid cannot be used together and it has been fixed

* Add busy_timeout to SQL options for both LB and API server

* Fix license name in swagger config

* Remove unnecessary SQLite prerequisite in docs