### PR TITLE
Fix cmd exection mode detection

### DIFF
--- a/pkg/api/resource/slurm/manager.go
+++ b/pkg/api/resource/slurm/manager.go
@@ -44,8 +44,6 @@ type slurmScheduler struct {
 const slurmBatchScheduler = "slurm"
 
 var (
-	slurmUserUID    int
-	slurmUserGID    int
 	slurmTimeFormat = base.DatetimeLayout + "-0700"
 	jobLock         = sync.RWMutex{}
 	assocLock       = sync.RWMutex{}
@@ -150,6 +148,8 @@ func (s *slurmScheduler) fetchFromSacct(ctx context.Context, start time.Time, en
 	// Execute sacct command between start and end times
 	sacctOutput, err := s.runSacctCmd(ctx, startTime, endTime)
 	if err != nil {
+		level.Error(s.logger).Log("msg", "Failed to run sacct command", "cluster_id", s.cluster.ID, "err", err)
+
 		return []models.Unit{}, err
 	}
 
@@ -172,6 +172,8 @@ func (s *slurmScheduler) fetchFromSacctMgr(
 	// Execute sacctmgr command
 	sacctMgrOutput, err := s.runSacctMgrCmd(ctx)
 	if err != nil {
+		level.Error(s.logger).Log("msg", "Failed to run sacctmgr command", "cluster_id", s.cluster.ID, "err", err)
+
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
* We drop all privs by the time we come to execution mode detection. So, we need to check if process has caps for capability mode. Use sudo as last option.

* Seems like exeucting with slurm user is not guaranteed to give jobs of all users. So we always execute the command using root user