### PR TITLE
Use custom header to find target cluster

### DIFF
--- a/pkg/lb/cli/cli_test.go
+++ b/pkg/lb/cli/cli_test.go
@@ -22,13 +22,14 @@ var mockCEEMSLBApp = *kingpin.New(
 	"Mock Load Balancer App.",
 )
 
-func queryLB(address string) error {
+func queryLB(address, clusterID string) error {
 	req, err := http.NewRequest(http.MethodGet, "http://"+address, nil) //nolint:noctx
 	if err != nil {
 		return err
 	}
 
 	req.Header.Add("X-Grafana-User", "usr1")
+	req.Header.Add("X-Ceems-Cluster-Id", clusterID)
 
 	client := &http.Client{Timeout: 10 * time.Second}
 
@@ -96,7 +97,7 @@ ceems_lb:
 
 	// Query LB
 	for i := range 10 {
-		if err := queryLB("localhost:9030/default"); err == nil {
+		if err := queryLB("localhost:9030", "default"); err == nil {
 			break
 		}
 

--- a/pkg/lb/frontend/frontend.go
+++ b/pkg/lb/frontend/frontend.go
@@ -42,7 +42,7 @@ type QueryParamsContextKey struct{}
 
 // QueryParams is the context value.
 type QueryParams struct {
-	id          string
+	clusterID   string
 	uuids       []string
 	queryPeriod time.Duration
 }
@@ -315,7 +315,7 @@ func (lb *loadBalancer) Serve(w http.ResponseWriter, r *http.Request) {
 
 	if v, ok := queryParams.(*QueryParams); ok {
 		queryPeriod = v.queryPeriod
-		id = v.id
+		id = v.clusterID
 	} else {
 		http.Error(w, "Invalid query parameters", http.StatusBadRequest)
 

--- a/pkg/lb/frontend/frontend_test.go
+++ b/pkg/lb/frontend/frontend_test.go
@@ -140,7 +140,7 @@ func TestNewFrontendSingleGroup(t *testing.T) {
 			newReq = request.WithContext(
 				context.WithValue(
 					request.Context(), QueryParamsContextKey{},
-					&QueryParams{queryPeriod: period, id: clusterID},
+					&QueryParams{queryPeriod: period, clusterID: clusterID},
 				),
 			)
 		} else {
@@ -164,7 +164,7 @@ func TestNewFrontendSingleGroup(t *testing.T) {
 	newReq := request.WithContext(
 		context.WithValue(
 			request.Context(), QueryParamsContextKey{},
-			&QueryParams{id: "default"},
+			&QueryParams{clusterID: "default"},
 		),
 	)
 	responseRecorder := httptest.NewRecorder()
@@ -260,7 +260,7 @@ func TestNewFrontendTwoGroups(t *testing.T) {
 			newReq = request.WithContext(
 				context.WithValue(
 					request.Context(), QueryParamsContextKey{},
-					&QueryParams{queryPeriod: period, id: test.clusterID},
+					&QueryParams{queryPeriod: period, clusterID: test.clusterID},
 				),
 			)
 		} else {
@@ -284,7 +284,7 @@ func TestNewFrontendTwoGroups(t *testing.T) {
 	newReq := request.WithContext(
 		context.WithValue(
 			request.Context(), QueryParamsContextKey{},
-			&QueryParams{id: "rm-0"},
+			&QueryParams{clusterID: "rm-0"},
 		),
 	)
 	responseRecorder := httptest.NewRecorder()

--- a/pkg/lb/frontend/helpers_test.go
+++ b/pkg/lb/frontend/helpers_test.go
@@ -204,10 +204,10 @@ func TestParseQueryParams(t *testing.T) {
 			req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 		}
 
-		newReq := parseQueryParams(req, test.rmIDs, log.NewNopLogger())
+		newReq := parseQueryParams(req, log.NewNopLogger())
 		queryParams := newReq.Context().Value(QueryParamsContextKey{}).(*QueryParams) //nolint:forcetypeassert
 		assert.Equal(t, queryParams.uuids, test.uuids)
-		assert.Equal(t, queryParams.id, test.rmID)
+		assert.Equal(t, queryParams.clusterID, test.rmID)
 
 		if test.method == "POST" {
 			// Check the new request body can still be parsed

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -717,7 +717,7 @@ then
 
     waitport "${port}"
 
-    get -H "X-Grafana-User: usr1" "127.0.0.1:${port}/slurm-0/api/v1/status/config" > "${fixture_output}"
+    get -H "X-Grafana-User: usr1" -H "X-Ceems-Cluster-Id: slurm-0" "127.0.0.1:${port}/api/v1/status/config" > "${fixture_output}"
 
   elif [[ "${scenario}" = "lb-forbid-user-query-db" ]] 
   then
@@ -746,7 +746,7 @@ then
 
     waitport "${port}"
 
-    get -H "X-Grafana-User: usr1" "127.0.0.1:${port}/slurm-1/api/v1/query?query=foo\{uuid=\"1481510\"\}&time=1713032179.506" > "${fixture_output}"
+    get -H "X-Grafana-User: usr1" -H "X-Ceems-Cluster-Id: slurm-1" "127.0.0.1:${port}/api/v1/query?query=foo\{uuid=\"1481510\"\}&time=1713032179.506" > "${fixture_output}"
 
   elif [[ "${scenario}" = "lb-allow-user-query-db" ]] 
   then
@@ -775,7 +775,7 @@ then
 
     waitport "${port}"
 
-    get -H "X-Grafana-User: usr1" "127.0.0.1:${port}/slurm-0/api/v1/query?query=foo\{uuid=\"1479763\"\}&time=${timestamp}" > "${fixture_output}"
+    get -H "X-Grafana-User: usr1" -H "X-Ceems-Cluster-Id: slurm-0" "127.0.0.1:${port}/api/v1/query?query=foo\{uuid=\"1479763\"\}&time=${timestamp}" > "${fixture_output}"
 
   elif [[ "${scenario}" = "lb-forbid-user-query-api" ]] 
   then
@@ -825,7 +825,7 @@ then
 
     waitport "${port}"
 
-    get -H "X-Grafana-User: usr1" "127.0.0.1:${port}/slurm-1/api/v1/query?query=foo\{uuid=\"1481510\"\}&time=${timestamp}" > "${fixture_output}"
+    get -H "X-Grafana-User: usr1" -H "X-Ceems-Cluster-Id: slurm-1" "127.0.0.1:${port}/api/v1/query?query=foo\{uuid=\"1481510\"\}&time=${timestamp}" > "${fixture_output}"
 
   elif [[ "${scenario}" = "lb-allow-user-query-api" ]] 
   then
@@ -875,7 +875,7 @@ then
 
     waitport "${port}"
 
-    get -H "X-Grafana-User: usr1" "127.0.0.1:${port}/slurm-0/api/v1/query?query=foo\{uuid=\"1479763\"\}&time=${timestamp}" > "${fixture_output}"
+    get -H "X-Grafana-User: usr1" -H "X-Ceems-Cluster-Id: slurm-0" "127.0.0.1:${port}/api/v1/query?query=foo\{uuid=\"1479763\"\}&time=${timestamp}" > "${fixture_output}"
 
   elif [[ "${scenario}" = "lb-allow-admin-query" ]] 
   then
@@ -904,7 +904,7 @@ then
 
     waitport "${port}"
 
-    get -H "X-Grafana-User: grafana" -H "Content-Type: application/x-www-form-urlencoded" -X POST -d "query=foo{uuid=\"1479765\"}&time=${timestamp}" "127.0.0.1:${port}/slurm-1/api/v1/query" > "${fixture_output}"
+    get -H "X-Grafana-User: grafana" -H "X-Ceems-Cluster-Id: slurm-1" -H "Content-Type: application/x-www-form-urlencoded" -X POST -d "query=foo{uuid=\"1479765\"}&time=${timestamp}" "127.0.0.1:${port}/api/v1/query" > "${fixture_output}"
 
   elif [[ "${scenario}" = "lb-auth" ]] 
   then
@@ -934,7 +934,7 @@ then
 
     waitport "${port}"
 
-    get -H "X-Grafana-User: usr1" "127.0.0.1:${port}/slurm-1/api/v1/status/config" > "${fixture_output}"
+    get -H "X-Grafana-User: usr1" -H "X-Ceems-Cluster-Id: slurm-1" "127.0.0.1:${port}/api/v1/status/config" > "${fixture_output}"
   fi
 fi
 

--- a/website/docs/components/ceems-lb.md
+++ b/website/docs/components/ceems-lb.md
@@ -6,33 +6,33 @@ sidebar_position: 3
 
 ## Background
 
-The motivation behind creating CEEMS load balancer component is that Prometheus TSDB 
-do not enforce any sort of access control over its metrics querying. This means once 
-a user has been given the permissions to query a Prometheus TSDB, they can query _any_ 
-metrics stored in the TSDB. 
+The motivation behind creating CEEMS load balancer component is that Prometheus TSDB
+do not enforce any sort of access control over its metrics querying. This means once
+a user has been given the permissions to query a Prometheus TSDB, they can query _any_
+metrics stored in the TSDB.
 
-Generally, it is not necessary to expose TSDB to end users directly and it is done 
-using Grafana as Prometheus datasource. Dashboards that are exposed to the end users 
-need to have query access on the underlying 
-datasource that the dashboard uses. Although a regular user with 
-[`Viewer`](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/#basic-roles) 
-role cannot add more panels to an existing dashboard, in order to _view_ the metrics the 
+Generally, it is not necessary to expose TSDB to end users directly and it is done
+using Grafana as Prometheus datasource. Dashboards that are exposed to the end users
+need to have query access on the underlying
+datasource that the dashboard uses. Although a regular user with
+[`Viewer`](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/#basic-roles)
+role cannot add more panels to an existing dashboard, in order to _view_ the metrics the
 user has effectively `query` permissions on the datasource.
 
-This effectively means, the user can make _any_ query to the underlying datasource, _e.g.,_ 
-Prometheus, using the browser cookie that is set by Grafana auth. The consequence is that 
-the user can query the metrics of _any_ user or _any_ compute unit. Straight forward 
-solutions to this problem is to create a Prometheus instance for each project/namespace. 
-However, this is not a scalable solution when they are thousands of projects/namespaces 
-exist. 
+This effectively means, the user can make _any_ query to the underlying datasource, _e.g.,_
+Prometheus, using the browser cookie that is set by Grafana auth. The consequence is that
+the user can query the metrics of _any_ user or _any_ compute unit. Straight forward
+solutions to this problem is to create a Prometheus instance for each project/namespace.
+However, this is not a scalable solution when they are thousands of projects/namespaces
+exist.
 
-This can pose few issues in multi tenant systems like HPC and cloud computing platforms. 
-Ideally, we do not want one user to be able to access the compute unit metrics of 
+This can pose few issues in multi tenant systems like HPC and cloud computing platforms.
+Ideally, we do not want one user to be able to access the compute unit metrics of
 other users. CEEMS load balancer component has been created to address this issue.
 
-CEEMS Load Balancer addresses this issue by acting as a gate keeper to introspect the 
-query before deciding whether to proxy the request to TSDB or not. It means when a user 
-makes a TSDB query for a given compute unit, CEEMS load balancer will check if the user 
+CEEMS Load Balancer addresses this issue by acting as a gate keeper to introspect the
+query before deciding whether to proxy the request to TSDB or not. It means when a user
+makes a TSDB query for a given compute unit, CEEMS load balancer will check if the user
 owns that compute unit by verifying with CEEMS API server.
 
 ## Objectives
@@ -43,51 +43,51 @@ The main objectives of the CEEMS load balancer are two-fold:
 are only accessible to the members of that project/namespace
 - To provide basic load balancing for replicated TSDB instances.
 
-Thus, CEEMS load balancer can be configured as Prometheus data source in Grafana and 
-the load balancer will take care of routing traffic to backend TSDB instances and at 
+Thus, CEEMS load balancer can be configured as Prometheus data source in Grafana and
+the load balancer will take care of routing traffic to backend TSDB instances and at
 the same time enforcing access control.
 
 ## Load balancing
 
-CEEMS load balancer supports classic load balancing strategies like round-robin and least 
-connection methods. Besides these two, it supports resource based strategy that is 
+CEEMS load balancer supports classic load balancing strategies like round-robin and least
+connection methods. Besides these two, it supports resource based strategy that is
 based on retention time. Let's take a look at this strategy in-detail.
 
-Taking Prometheus TSDB as an example, Prometheus advises to use local file system to store 
-the data. This ensure performance and data integrity. However, storing data on local 
-disk is not fault tolerant unless data is replicated elsewhere. There are cloud native 
-projects like [Thanos](https://thanos.io/), [Cortex](https://cortexmetrics.io/) to 
-address this issue. This load balancer is meant 
+Taking Prometheus TSDB as an example, Prometheus advises to use local file system to store
+the data. This ensure performance and data integrity. However, storing data on local
+disk is not fault tolerant unless data is replicated elsewhere. There are cloud native
+projects like [Thanos](https://thanos.io/), [Cortex](https://cortexmetrics.io/) to
+address this issue. This load balancer is meant
 to provide the basic functionality proposed by Thanos, Cortex, _etc_.
 
-The core idea is to replicate the Prometheus data using 
-[Prometheus' remote write](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write) 
-functionality onto a remote storage which 
-is fault tolerant and have higher storage capacity but with a degraded query performance. 
+The core idea is to replicate the Prometheus data using
+[Prometheus' remote write](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write)
+functionality onto a remote storage which
+is fault tolerant and have higher storage capacity but with a degraded query performance.
 In this scenario, we have two TSDBs with following characteristics:
 
 - TSDB using local disk: faster query performance with limited storage space
 - TSDB using remote storage: slower query performance with bigger storage space
 
-TSDB using local disk ("hot" instance) will have shorter retention period and the 
+TSDB using local disk ("hot" instance) will have shorter retention period and the
 one using remote storage ("cold" instance)
 can have longer retention. CEEMS load balancer is capable of introspecting the query and
 then routing the request to either "hot" or "cold" instances of TSDB.
 
 ## Multi cluster support
 
-A single deployment of CEEMS load balancer is capable of loading balancing traffic between 
-different replicated TSDB instances of multiple clusters. Imagine there are two different 
-clusters, one for SLURM and one for Openstack, in a DC. Slurm cluster has two dedicated 
-TSDB instances where data is replicated between them and the same for Openstack cluster. 
-Thus, in total, there are four TSDB instances, two for SLURM cluster and two for 
-Openstack cluster. A single instance of CEEMS load balancer can route the traffic 
+A single deployment of CEEMS load balancer is capable of loading balancing traffic between
+different replicated TSDB instances of multiple clusters. Imagine there are two different
+clusters, one for SLURM and one for Openstack, in a DC. Slurm cluster has two dedicated
+TSDB instances where data is replicated between them and the same for Openstack cluster.
+Thus, in total, there are four TSDB instances, two for SLURM cluster and two for
+Openstack cluster. A single instance of CEEMS load balancer can route the traffic
 between these four different TSDB instances by targeting the correct cluster.
 
-However, in the production with heavy traffic a single instance of CEEMS load balancer 
-might not be a optimal solution. In that case, it is however possible to deploy a dedicated 
+However, in the production with heavy traffic a single instance of CEEMS load balancer
+might not be a optimal solution. In that case, it is however possible to deploy a dedicated
 CEEMS load balancer for each cluster.
 
-More details on how to configuration of multi-clusters can be found in [Configuration](../configuration/ceems-lb.md) 
-section and some example scenarios are discussed in [Advanced](../advanced/multi-cluster.md) 
+More details on how to configuration of multi-clusters can be found in [Configuration](../configuration/ceems-lb.md)
+section and some example scenarios are discussed in [Advanced](../advanced/multi-cluster.md)
 section.

--- a/website/docs/configuration/config-reference.md
+++ b/website/docs/configuration/config-reference.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 9
 ---
 
 # Configuration Reference


### PR DESCRIPTION
* Instead of using path parameter, which can confuse users, use a custom header that will be read by LB and then redirect the query to correct backend. This should work for most of the datasources as we can always add custom headers in Grafana. This will also avoid having to manipulate path manually after stripping path parameter.

* Update tests and docs accordingly.

* Add note in docs that it is possible to find target cluster using query labels and show how to do it.