### PR TITLE
Implement correct scaling of perf hardware counters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.18.1
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
-	github.com/hodgesds/perf-utils v0.7.0
 	github.com/jellydator/ttlcache/v3 v3.3.0
+	github.com/mahendrapaipuri/perf-utils v0.0.0-20241102115757-6c72709e1c07
 	github.com/mattn/go-sqlite3 v1.14.24
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/common v0.60.1

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,6 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
-github.com/hodgesds/perf-utils v0.7.0 h1:7KlHGMuig4FRH5fNw68PV6xLmgTe7jKs9hgAcEAbioU=
-github.com/hodgesds/perf-utils v0.7.0/go.mod h1:LAklqfDadNKpkxoAJNHpD5tkY0rkZEVdnCEWN5k4QJY=
 github.com/jellydator/ttlcache/v3 v3.3.0 h1:BdoC9cE81qXfrxeb9eoJi9dWrdhSuwXMAnHTbnBm4Wc=
 github.com/jellydator/ttlcache/v3 v3.3.0/go.mod h1:bj2/e0l4jRnQdrnSTaGTsh4GSXvMjQcy41i7th0GVGw=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -76,6 +74,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/mahendrapaipuri/perf-utils v0.0.0-20241102115757-6c72709e1c07 h1:FssguDihSIG+XLpvLVNXNr8AfoSwTrNaAqWsbYTA1sE=
+github.com/mahendrapaipuri/perf-utils v0.0.0-20241102115757-6c72709e1c07/go.mod h1:B3EnGJVDIBJ9PRO9cngEsv/p1nmOgfxB2eKS8yhbrSM=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-sqlite3 v1.14.24 h1:tpSp2G2KyMnnQu99ngJ47EIkWVmliIizyZBfPrBWDRM=

--- a/pkg/collector/perf.go
+++ b/pkg/collector/perf.go
@@ -572,7 +572,7 @@ func (c *perfCollector) Update(ch chan<- prometheus.Metric, cgroups []cgroup) er
 	}
 
 	// Update metrics in go routines for each cgroup
-	// TODO: Update concurrently and manage state variables better?
+	// NOTE: Update concurrently and manage state variables better?
 	for _, cgroup := range cgroups {
 		uuid := cgroup.uuid
 


### PR DESCRIPTION
* Upstream perf-utils package exports enabled and running times of a random event when multiple events are selected. This can pose problems when different events have different multiplexing ratios and we noticed that in our tests.

* We forked the upstream package to export enabled and running times of each event and estimate correct scaling factor for each event.