### PR TITLE
Support automatic token rotation for Openstack

### DIFF
--- a/build/config/ceems_api_server/ceems_api_server.yml
+++ b/build/config/ceems_api_server/ceems_api_server.yml
@@ -299,15 +299,8 @@ clusters: []
   #     # An object of environment variables that will be injected while executing the 
   #     # CLI utilities to fetch compute unit data. 
   #     #
-  #     # This is handy when executing CLI tools like `keystone` for openstack or `kubectl` 
-  #     # for k8s needs to source admin credentials. Those credentials can be set manually
-  #     # here in this section. 
-  #     #
   #     environment_variables: {}
-  #       # OS_USERNAME: username  # Openstack RC File
-  #       # OS_PASSWORD: password  # Openstack RC File
-  #       # OS_TENANT_NAME: projectName  # Openstack RC File
-  #       # OS_AUTH_URL: https://identityHost:portNumber/v2.0  # Openstack RC File
+  #       # NAME: value  # Environment variable name value pair
 
   #   # If the resource manager supports API server, configure the REST API
   #   # server details here.
@@ -459,23 +452,27 @@ clusters: []
   #   # Any other configuration needed to reach API server of the resource manager
   #   # can be configured in this section.
   #   #
-  #   # Currently this section is used for both SLURM and Openstack resource managers
+  #   # Currently this section is used for Openstack resource manager
   #   # to configure API versions
   #   #
-  #   # For example, for SLURM if your API endpoints are of form `/slurm/v0.0.40/diag`, 
-  #   # the version is `v0.0.40`.
-  #   # Docs: https://slurm.schedmd.com/rest_api.html
-  #   # SLURM's REST API version can be set as `slurm: v0.0.40`
+  #   # In the case of Openstack, this section must have two keys `api_service_endpoints`
+  #   # and `auth`. Both of these are compulsory.
+  #   # `api_service_endpoints` must provide API endpoints for compute and identity
+  #   # services as provided in service catalog of Openstack cluster. `auth` must be the
+  #   # same `auth` object that must be sent in POST request to keystone to get a API token.
   #   #
-  #   # In the case of Openstack, we need to fetch from different sources like identity,
-  #   # compute and they use different versioning of API. They can be configured using
-  #   # this section as well
-  #   #
-  #   extra_config:
-  #     api_versions: {}
-  #       # slurm: v0.0.40  # SLURM
-  #       # identity: v3  # Openstack
-  #       # compute: v2.1  # Openstack
+  #   extra_config: {}
+  #      # api_service_endpoints:
+  #      #   compute: https://openstack-nova.example.com/v2.1
+  #      #   identity: https://openstack-keystone.example.com
+  #      # auth:
+  #      #   identity:
+  #      #     methods:
+  #      #       - password
+  #      #     password:
+  #      #       user:
+  #      #         name: admin
+  #      #         password: supersecret
     
 # A list of Updaters that will be used to update the compute unit metrics. This update 
 # step can be used to update the aggregate metrics of each compute unit in real time

--- a/build/package/ceems_api_server/ceems_api_server.service
+++ b/build/package/ceems_api_server/ceems_api_server.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Prometheus CEEMS API Server
+Description=CEEMS API Server
 After=network-online.target
 
 [Service]

--- a/internal/common/helpers.go
+++ b/internal/common/helpers.go
@@ -57,6 +57,51 @@ func GetUUIDFromString(stringSlice []string) (string, error) {
 	return uuid.String(), err
 }
 
+// ConvertMapI2MapS walks the given dynamic object recursively, and
+// converts maps with interface{} key type to maps with string key type.
+// This function comes handy if you want to marshal a dynamic object into
+// JSON where maps with interface{} key type are not allowed.
+//
+// Recursion is implemented into values of the following types:
+//
+//	-map[interface{}]interface{}
+//	-map[string]interface{}
+//	-[]interface{}
+//
+// When converting map[interface{}]interface{} to map[string]interface{},
+// fmt.Sprint() with default formatting is used to convert the key to a string key.
+//
+// Nicked from https://github.com/icza/dyno
+func ConvertMapI2MapS(v interface{}) interface{} {
+	switch x := v.(type) {
+	case map[interface{}]interface{}:
+		m := map[string]interface{}{}
+
+		for k, v2 := range x {
+			switch k2 := k.(type) {
+			case string: // Fast check if it's already a string
+				m[k2] = ConvertMapI2MapS(v2)
+			default:
+				m[fmt.Sprint(k)] = ConvertMapI2MapS(v2)
+			}
+		}
+
+		v = m
+
+	case []interface{}:
+		for i, v2 := range x {
+			x[i] = ConvertMapI2MapS(v2)
+		}
+
+	case map[string]interface{}:
+		for k, v2 := range x {
+			x[k] = ConvertMapI2MapS(v2)
+		}
+	}
+
+	return v
+}
+
 // MakeConfig reads config file, merges with passed default config and returns updated
 // config instance.
 func MakeConfig[T any](filePath string) (*T, error) {

--- a/internal/common/helpers_test.go
+++ b/internal/common/helpers_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/mahendrapaipuri/ceems/pkg/grafana"
@@ -108,6 +109,78 @@ func TestGetUuid(t *testing.T) {
 
 	// Check if UUIDs match
 	assert.Equal(t, expected, got, "mismatched UUIDs")
+}
+
+func TestConvertMapI2MapS(t *testing.T) {
+	cases := []struct {
+		title string      // Title of the test case
+		v     interface{} // Input dynamic object
+		exp   interface{} // Expected result
+	}{
+		{
+			title: "nil value",
+			v:     nil,
+			exp:   nil,
+		},
+		{
+			title: "string value",
+			v:     "a",
+			exp:   "a",
+		},
+		{
+			title: "map[interfac{}]interface{} value",
+			v: map[interface{}]interface{}{
+				"s": "s",
+				1:   1,
+			},
+			exp: map[string]interface{}{
+				"s": "s",
+				"1": 1,
+			},
+		},
+		{
+			title: "nested maps and slices",
+			v: map[interface{}]interface{}{
+				"s": "s",
+				1:   1,
+				float64(0): []interface{}{
+					1,
+					"x",
+					map[interface{}]interface{}{
+						"s": "s",
+						2.0: 2,
+					},
+					map[string]interface{}{
+						"s": "s",
+						"1": 1,
+					},
+				},
+			},
+			exp: map[string]interface{}{
+				"s": "s",
+				"1": 1,
+				"0": []interface{}{
+					1,
+					"x",
+					map[string]interface{}{
+						"s": "s",
+						"2": 2,
+					},
+					map[string]interface{}{
+						"s": "s",
+						"1": 1,
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		v := ConvertMapI2MapS(c.v)
+		if !reflect.DeepEqual(v, c.exp) {
+			t.Errorf("[title: %s] Expected value: %v, got: %v", c.title, c.exp, c.v)
+		}
+	}
 }
 
 func TestMakeConfig(t *testing.T) {

--- a/pkg/api/testdata/config.yml
+++ b/pkg/api/testdata/config.yml
@@ -33,15 +33,21 @@ clusters:
       - tsdb-0
     web: 
       http_headers:
-        X-Auth-Token:
-          secrets:
-            - supersecrettoken
         X-OpenStack-Nova-API-Version:
           values:
             - latest
     extra_config:
-      compute_api_url: http://localhost:8080/v2.1
-      identity_api_url: http://localhost:7070
+      api_service_endpoints:
+        compute: http://localhost:8080/v2.1
+        identity: http://localhost:7070
+      auth:
+        identity:
+          methods:
+            - password
+          password:
+            user:
+              name: admin
+              password: supersecret
 
   - id: os-1
     manager: openstack
@@ -50,15 +56,20 @@ clusters:
       - tsdb-1
     web: 
       http_headers:
-        X-Auth-Token:
-          secrets:
-            - supersecrettoken
         X-OpenStack-Nova-API-Version:
           values:
             - latest
     extra_config:
-      compute_api_url: http://localhost:8080/v2.1
-      identity_api_url: http://localhost:7070
+      api_service_endpoints:
+        compute: http://localhost:8080/v2.1
+        identity: http://localhost:7070
+      auth:
+        identity:
+          methods:
+            - application_credential
+          application_credential:
+            id: 21dced0fd20347869b93710d2b98aae0
+            secret: supersecret
 
 updaters:
   - id: tsdb-0

--- a/website/docs/components/ceems-api-server.md
+++ b/website/docs/components/ceems-api-server.md
@@ -6,19 +6,19 @@ sidebar_position: 2
 
 ## Background
 
-CEEMS exporter exports compute unit and node level metrics to Prometheus. But this is 
-not enough to be able to query the metrics from Prometheus efficiently. Especially, for 
-batch jobs we need at least the timestamps of when the job has started and ended and 
-on which compute nodes to efficiently query the metrics. Storing these meta data of 
-the compute units in Prometheus is not ideal as they are not time series and using storing meta 
-data as labels can increase the cardinality very rapidly. 
+CEEMS exporter exports compute unit and node level metrics to Prometheus. But this is
+not enough to be able to query the metrics from Prometheus efficiently. Especially, for
+batch jobs we need at least the timestamps of when the job has started and ended and
+on which compute nodes to efficiently query the metrics. Storing these meta data of
+the compute units in Prometheus is not ideal as they are not time series and using storing meta
+data as labels can increase the cardinality very rapidly.
 
-At the same time, we would like to show to the end users aggregate metrics of their usage 
-which needs to make queries to Prometheus every time they load their dashboards. The 
-CEEMS API server has been introduced into the stack to address these limitations. CEEMS 
-API server is meant to store and server compute unit meta data, aggregate metrics of 
-compute units, users and projects _via_ API end points. This data will be gathered from 
-the underlying resource manager and keep it in a local DB based on SQLite. 
+At the same time, we would like to show to the end users aggregate metrics of their usage
+which needs to make queries to Prometheus every time they load their dashboards. The
+CEEMS API server has been introduced into the stack to address these limitations. CEEMS
+API server is meant to store and server compute unit meta data, aggregate metrics of
+compute units, users and projects _via_ API end points. This data will be gathered from
+the underlying resource manager and keep it in a local DB based on SQLite.
 
 :::important[IMPORTANT]
 
@@ -28,19 +28,19 @@ process.
 
 :::
 
-Effectively, it acts as an abstraction layer for different 
-resource managers and it is capable to storing data from different resource managers. 
-The advantage of this approach is that it acts a single point of data collection for 
-different resource managers of a data center and users will be able to consult their 
+Effectively, it acts as an abstraction layer for different
+resource managers and it is capable to storing data from different resource managers.
+The advantage of this approach is that it acts a single point of data collection for
+different resource managers of a data center and users will be able to consult their
 usage of their compute units in a unified way.
 
 :::note[NOTE]
 
-If the usernames are identical for different resource managers, _i.e.,_ if a data center 
-has SLURM and Openstack clusters and user identities for these two clusters are provided 
-by the same Identity Provider (IDP), it is possible for the Operators to use a 
-single deployment of CEEMS that uses the same IDP and expose the compute unit metrics 
-of both SLURM and Openstack clusters with the same instance of Grafana with 
+If the usernames are identical for different resource managers, _i.e.,_ if a data center
+has SLURM and Openstack clusters and user identities for these two clusters are provided
+by the same Identity Provider (IDP), it is possible for the Operators to use a
+single deployment of CEEMS that uses the same IDP and expose the compute unit metrics
+of both SLURM and Openstack clusters with the same instance of Grafana with
 different dashboards.
 
 :::
@@ -52,17 +52,17 @@ CEEMS API server primarily serves for two objectives:
 - To store the compute unit information of different resource managers in a unified way.
 The information we need is very basic like unique identifier of compute unit, project it
 belongs to, owner, current state, when it has started, resources allocated, _etc_.
-- To update aggregate metrics of each compute unit by querying the TSDB in realtime. 
-This allows the end users to view the usage of their workloads in realtime like CPU, 
+- To update aggregate metrics of each compute unit by querying the TSDB in realtime.
+This allows the end users to view the usage of their workloads in realtime like CPU,
 energy, emissions, _etc_.
 - To keep latest copy of users and their associated projects to enforce access control.
 
-When coupled with 
-[JSON API DataSource](https://grafana.github.io/grafana-json-datasource/installation/) or 
+When coupled with
+[JSON API DataSource](https://grafana.github.io/grafana-json-datasource/installation/) or
 [Infinity DataSource](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/)
-of Grafana, we can list the compute units of a user 
-along with the metadata and aggregate metrics of each unit. The stored metadata in the 
-CEEMS API server DB will allow us to construct the URLs for the Grafana dashboards for 
+of Grafana, we can list the compute units of a user
+along with the metadata and aggregate metrics of each unit. The stored metadata in the
+CEEMS API server DB will allow us to construct the URLs for the Grafana dashboards for
 each compute dynamically based on start and end time of each compute unit.
 
 ![User job list](/img/dashboards/job_list_user.png)
@@ -71,53 +71,53 @@ each compute dynamically based on start and end time of each compute unit.
 
 ### Resource Managers
 
-Now that it is clear that CEEMS _can_ support different resource managers, it is time 
-to explain how CEEMS actually supports them. CEEMS has its own DB schema that stores 
-compute units metrics and meta data. Let's take meta data of each compute unit as an 
-example. For example, SLURM exposes meta data of jobs using either `sacct` command or 
-SLURM REST API. Openstack does it too using Keystone and Nova API servers so does the 
-Kubernetes with its API server. However, all these managers expose these meta data 
-in different ways each having their own API spec. 
+Now that it is clear that CEEMS _can_ support different resource managers, it is time
+to explain how CEEMS actually supports them. CEEMS has its own DB schema that stores
+compute units metrics and meta data. Let's take meta data of each compute unit as an
+example. For example, SLURM exposes meta data of jobs using either `sacct` command or
+SLURM REST API. Openstack does it too using Keystone and Nova API servers so does the
+Kubernetes with its API server. However, all these managers expose these meta data
+in different ways each having their own API spec.
 
-CEEMS API server must implement each of this resource manager to fetch compute unit 
+CEEMS API server must implement each of this resource manager to fetch compute unit
 meta data and store it in CEEMS API server's DB. This is done using factory design
-pattern and implemented in an extensible way. That means operators can implement their 
-own custom third party resource managers and plug into CEEMS API server. Essentially, 
-this translates to implementing two interfaces, one for fetching compute units and one 
-for fetching users and projects/namespaces/tenants data from the underlying resource 
-manager. 
+pattern and implemented in an extensible way. That means operators can implement their
+own custom third party resource managers and plug into CEEMS API server. Essentially,
+this translates to implementing two interfaces, one for fetching compute units and one
+for fetching users and projects/namespaces/tenants data from the underlying resource
+manager.
 
-Currently, CEEMS API server ships SLURM support and soon Openstack support 
+Currently, CEEMS API server ships SLURM support and soon Openstack support
 will be added.
 
 ### Updaters
 
-As CEEMS API server must store aggregate metrics of each compute unit, it must query 
-some sort of external DB that stores time series metrics of the compute units to 
-estimate aggregate metrics. As CEEMS ships an exporter that is capable of exporting 
-metrics to a Prometheus TSDB, a straight forward approach is to deploy CEEMS exporter 
+As CEEMS API server must store aggregate metrics of each compute unit, it must query
+some sort of external DB that stores time series metrics of the compute units to
+estimate aggregate metrics. As CEEMS ships an exporter that is capable of exporting
+metrics to a Prometheus TSDB, a straight forward approach is to deploy CEEMS exporter
 on compute nodes and query Prometheus to estimate aggregate metrics.
 
-This is done using a sub-component of CEEMS API server called updater. The job of 
-updater is to update the compute units fetched by a given resource manager with the 
-aggregate metrics of that compute unit. Like in the case of resource manager, updater 
-uses factory design pattern and it is extensible. It is possible to use custom 
-third party tools to update the compute units with aggregate metrics. 
+This is done using a sub-component of CEEMS API server called updater. The job of
+updater is to update the compute units fetched by a given resource manager with the
+aggregate metrics of that compute unit. Like in the case of resource manager, updater
+uses factory design pattern and it is extensible. It is possible to use custom
+third party tools to update the compute units with aggregate metrics.
 
-Currently, CEEMS API server ships TSDB updater which is capable of estimating aggregate 
+Currently, CEEMS API server ships TSDB updater which is capable of estimating aggregate
 metrics using Prometheus TSDB server.
 
 ## Multi cluster support
 
-A single deployment of CEEMS API server must be able to fetch and serve aggregate metrics 
-of compute units of multiple clusters of either same resource manager or different 
-resource managers. This means single CEEMS API server can store and serve metrics data 
-of multiple SLURM, Openstack and Kubernetes clusters. 
+A single deployment of CEEMS API server must be able to fetch and serve aggregate metrics
+of compute units of multiple clusters of either same resource manager or different
+resource managers. This means single CEEMS API server can store and serve metrics data
+of multiple SLURM, Openstack and Kubernetes clusters.
 
-In the same way, irrespective of each cluster using its own dedicated TSDB or a shared 
-TSDB with other clusters, Updater sub component of CEEMS API server is capable of 
+In the same way, irrespective of each cluster using its own dedicated TSDB or a shared
+TSDB with other clusters, Updater sub component of CEEMS API server is capable of
 estimating aggregate metrics of each compute unit.
 
-More details on how to configuration of multi-clusters can be found in 
-[Configuration](../configuration/ceems-api-server.md) section and some example 
+More details on how to configuration of multi-clusters can be found in
+[Configuration](../configuration/ceems-api-server.md) section and some example
 scenarios are discussed in [Advanced](../advanced/multi-cluster.md) section.

--- a/website/docs/configuration/config-reference.md
+++ b/website/docs/configuration/config-reference.md
@@ -34,6 +34,7 @@ character in the source label should be converted to an underscore
 * `<updatername>`: a string that identifies updater type. Currently accepted values are `tsdb`.
 * `<promql_query>`: a valid PromQL query string.
 * `<lbstrategy>`: a valid load balancing strategy. Currently accepted values are `round-robin`, `least-connection` and `resource-based`.
+* `<object>`: a generic object
 
 The other placeholders are specified separately.
 
@@ -365,26 +366,32 @@ web:
 # Any other configuration needed to reach API server of the resource manager
 # can be configured in this section.
 #
-# Currently this section is used for both SLURM and Openstack resource managers
+# Currently this section is used for Openstack resource manager
 # to configure API versions
 #
-# For example, for SLURM if your API endpoints are of form `/slurm/v0.0.40/diag`, 
-# the version is `v0.0.40`.
-# Docs: https://slurm.schedmd.com/rest_api.html
-# SLURM's REST API version can be set as `slurm: v0.0.40`
-#
-# In the case of Openstack, we need to fetch from different sources like identity,
-# compute and they use different versioning of API. They can be configured using
-# this section as well
+# In the case of Openstack, this section must have two keys `api_service_endpoints`
+# and `auth`. Both of these are compulsory.
+# `api_service_endpoints` must provide API endpoints for compute and identity
+# services as provided in service catalog of Openstack cluster. `auth` must be the
+# same `auth` object that must be sent in POST request to keystone to get a API token.
 #
 # Example:
 #
-# slurm: v0.0.40  # SLURM
-# identity: v3  # Openstack
-# compute: v2.1  # Openstack
+# extra_config:
+#   api_service_endpoints:
+#     compute: https://openstack-nova.example.com/v2.1
+#     identity: https://openstack-keystone.example.com
+#   auth:
+#     identity:
+#       methods:
+#         - password
+#       password:
+#         user:
+#           name: admin
+#           password: supersecret
 #
 extra_config:
-  [ <string>: <string> ... ]
+  [ <string>: <object> ... ]
 ```
 
 ## `<updater_config>`


### PR DESCRIPTION
* By default Openstack's API tokens are only valid for 1 hour and AFAIK there is no way to generate tokens with long duration. This PR modifies the config accepted by Openstack manager and takes auth object as input. This auth object will be used to generate and rotate API tokens for every 1 hour.

* We accept the same auth object as Openstack so we pass this object to keystone transparently which allows us to support all forms of auth object without much code. It is the user's responsibility to pass correct auth object to clusters config.

* Add new handlers for mock servers and modify test resources appropriately

* Update docs