### PR TITLE
Set MIG instance in a separate label, when present

### DIFF
--- a/pkg/collector/libvirt.go
+++ b/pkg/collector/libvirt.go
@@ -261,6 +261,7 @@ func NewLibvirtCollector(logger *slog.Logger) (Collector, error) {
 				"index",
 				"hindex",
 				"gpuuuid",
+				"gpuiid",
 			},
 			nil,
 		),
@@ -420,10 +421,9 @@ func (c *libvirtCollector) updateGPUOrdinals(ch chan<- prometheus.Metric, instan
 			}
 
 		update_chan:
-			// We set label of gpuuuid of format <gpu_uuid>/<mig_instance_id>
-			// On the DCGM side, we need to use relabel magic to merge UUID
-			// and GPU_I_ID labels and set them exactly as <uuid>/<gpu_i_id>
-			// as well
+			// On the DCGM side, we need to use relabel magic to rename UUID
+			// and GPU_I_ID labels to gpuuuid and gpuiid and make operations
+			// on(gpuuuid,gpuiid)
 			ch <- prometheus.MustNewConstMetric(
 				c.instanceGpuFlag,
 				prometheus.GaugeValue,
@@ -433,7 +433,8 @@ func (c *libvirtCollector) updateGPUOrdinals(ch chan<- prometheus.Metric, instan
 				p.uuid,
 				gpuOrdinal,
 				fmt.Sprintf("%s/gpu-%s", c.hostname, gpuOrdinal),
-				fmt.Sprintf("%s/%s", gpuuuid, miggid),
+				gpuuuid,
+				miggid,
 			)
 		}
 	}

--- a/pkg/collector/slurm.go
+++ b/pkg/collector/slurm.go
@@ -240,6 +240,7 @@ func NewSlurmCollector(logger *slog.Logger) (Collector, error) {
 				"index",
 				"hindex",
 				"gpuuuid",
+				"gpuiid",
 			},
 			nil,
 		),
@@ -390,10 +391,9 @@ func (c *slurmCollector) updateGPUOrdinals(ch chan<- prometheus.Metric, jobProps
 			}
 
 		update_chan:
-			// We set label of gpuuuid of format <gpu_uuid>/<mig_instance_id>
-			// On the DCGM side, we need to use relabel magic to merge UUID
-			// and GPU_I_ID labels and set them exactly as <uuid>/<gpu_i_id>
-			// as well
+			// On the DCGM side, we need to use relabel magic to rename UUID
+			// and GPU_I_ID labels to gpuuuid and gpuiid and make operations
+			// on(gpuuuid,gpuiid)
 			ch <- prometheus.MustNewConstMetric(
 				c.jobGpuFlag,
 				prometheus.GaugeValue,
@@ -403,7 +403,8 @@ func (c *slurmCollector) updateGPUOrdinals(ch chan<- prometheus.Metric, jobProps
 				p.uuid,
 				gpuOrdinal,
 				fmt.Sprintf("%s/gpu-%s", c.hostname, gpuOrdinal),
-				fmt.Sprintf("%s/%s", gpuuuid, miggid),
+				gpuuuid,
+				miggid,
 			)
 		}
 	}

--- a/pkg/collector/testdata/output/exporter/e2e-test-cgroupsv1-libvirt-output.txt
+++ b/pkg/collector/testdata/output/exporter/e2e-test-cgroupsv1-libvirt-output.txt
@@ -48,12 +48,12 @@ ceems_compute_unit_cpus{hostname="",manager="libvirt",uuid="57f2d45e-8ddf-4338-9
 ceems_compute_unit_cpus{hostname="",manager="libvirt",uuid="b674a0a2-c300-4dc6-8c9c-65df16da6d69"} 0
 # HELP ceems_compute_unit_gpu_index_flag A value > 0 indicates running instance using current GPU
 # TYPE ceems_compute_unit_gpu_index_flag gauge
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-61a65011-6571-a64n-5ab8-66cbb6f7f9c3/",hindex="/gpu-9",hostname="",index="9",manager="libvirt",uuid="2896bdd5-dbc2-4339-9d8e-ddd838bf35d3"} 1
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-61a65011-6571-a6d2-5ab8-66cbb6f7f9c3/",hindex="/gpu-1",hostname="",index="1",manager="libvirt",uuid="57f2d45e-8ddf-4338-91df-62d0044ff1b5"} 1
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-61a65011-6571-a6d2-5th8-66cbb6f7f9c3/",hindex="/gpu-8",hostname="",index="8",manager="libvirt",uuid="57f2d45e-8ddf-4338-91df-62d0044ff1b5"} 1
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-6cc98505-fdde-461e-a93c-6935fba45a27/",hindex="/gpu-11",hostname="",index="11",manager="libvirt",uuid="2896bdd5-dbc2-4339-9d8e-ddd838bf35d3"} 1
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-956348bc-d43d-23ed-53d4-857749fa2b67/5",hindex="/gpu-3",hostname="",index="3",manager="libvirt",uuid="b674a0a2-c300-4dc6-8c9c-65df16da6d69"} 0.1
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-f124aa59-d406-d45b-9481-8fcd694e6c9e/",hindex="/gpu-0",hostname="",index="0",manager="libvirt",uuid="b674a0a2-c300-4dc6-8c9c-65df16da6d69"} 0.5
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="GPU-61a65011-6571-a64n-5ab8-66cbb6f7f9c3",hindex="/gpu-9",hostname="",index="9",manager="libvirt",uuid="2896bdd5-dbc2-4339-9d8e-ddd838bf35d3"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="GPU-61a65011-6571-a6d2-5ab8-66cbb6f7f9c3",hindex="/gpu-1",hostname="",index="1",manager="libvirt",uuid="57f2d45e-8ddf-4338-91df-62d0044ff1b5"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="GPU-61a65011-6571-a6d2-5th8-66cbb6f7f9c3",hindex="/gpu-8",hostname="",index="8",manager="libvirt",uuid="57f2d45e-8ddf-4338-91df-62d0044ff1b5"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="GPU-6cc98505-fdde-461e-a93c-6935fba45a27",hindex="/gpu-11",hostname="",index="11",manager="libvirt",uuid="2896bdd5-dbc2-4339-9d8e-ddd838bf35d3"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="GPU-f124aa59-d406-d45b-9481-8fcd694e6c9e",hindex="/gpu-0",hostname="",index="0",manager="libvirt",uuid="b674a0a2-c300-4dc6-8c9c-65df16da6d69"} 0.5
+ceems_compute_unit_gpu_index_flag{gpuiid="5",gpuuuid="GPU-956348bc-d43d-23ed-53d4-857749fa2b67",hindex="/gpu-3",hostname="",index="3",manager="libvirt",uuid="b674a0a2-c300-4dc6-8c9c-65df16da6d69"} 0.1
 # HELP ceems_compute_unit_memory_cache_bytes Memory cache used in bytes
 # TYPE ceems_compute_unit_memory_cache_bytes gauge
 ceems_compute_unit_memory_cache_bytes{hostname="",manager="libvirt",uuid="2896bdd5-dbc2-4339-9d8e-ddd838bf35d3"} 2.1086208e+07

--- a/pkg/collector/testdata/output/exporter/e2e-test-cgroupsv1-memory-subsystem-output.txt
+++ b/pkg/collector/testdata/output/exporter/e2e-test-cgroupsv1-memory-subsystem-output.txt
@@ -15,10 +15,10 @@ ceems_compute_unit_cpus{hostname="",manager="slurm",uuid="1009249"} 0
 ceems_compute_unit_cpus{hostname="",manager="slurm",uuid="1009250"} 0
 # HELP ceems_compute_unit_gpu_index_flag A value > 0 indicates the job using current GPU
 # TYPE ceems_compute_unit_gpu_index_flag gauge
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-61a65011-6571-a6d2-5ab8-66cbb6f7f9c3/",hindex="/gpu-1",hostname="",index="1",manager="slurm",uuid="1009250"} 1
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-956348bc-d43d-23ed-53d4-857749fa2b67/1",hindex="/gpu-2",hostname="",index="2",manager="slurm",uuid="1009248"} 0.6
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-956348bc-d43d-23ed-53d4-857749fa2b67/5",hindex="/gpu-3",hostname="",index="3",manager="slurm",uuid="1009248"} 0.2
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-f124aa59-d406-d45b-9481-8fcd694e6c9e/",hindex="/gpu-0",hostname="",index="0",manager="slurm",uuid="1009249"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="GPU-61a65011-6571-a6d2-5ab8-66cbb6f7f9c3",hindex="/gpu-1",hostname="",index="1",manager="slurm",uuid="1009250"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="GPU-f124aa59-d406-d45b-9481-8fcd694e6c9e",hindex="/gpu-0",hostname="",index="0",manager="slurm",uuid="1009249"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="1",gpuuuid="GPU-956348bc-d43d-23ed-53d4-857749fa2b67",hindex="/gpu-2",hostname="",index="2",manager="slurm",uuid="1009248"} 0.6
+ceems_compute_unit_gpu_index_flag{gpuiid="5",gpuuuid="GPU-956348bc-d43d-23ed-53d4-857749fa2b67",hindex="/gpu-3",hostname="",index="3",manager="slurm",uuid="1009248"} 0.2
 # HELP ceems_compute_unit_memory_cache_bytes Memory cache used in bytes
 # TYPE ceems_compute_unit_memory_cache_bytes gauge
 ceems_compute_unit_memory_cache_bytes{hostname="",manager="slurm",uuid="1009248"} 2.1086208e+07

--- a/pkg/collector/testdata/output/exporter/e2e-test-cgroupsv1-output.txt
+++ b/pkg/collector/testdata/output/exporter/e2e-test-cgroupsv1-output.txt
@@ -15,10 +15,10 @@ ceems_compute_unit_cpus{hostname="",manager="slurm",uuid="1009249"} 0
 ceems_compute_unit_cpus{hostname="",manager="slurm",uuid="1009250"} 0
 # HELP ceems_compute_unit_gpu_index_flag A value > 0 indicates the job using current GPU
 # TYPE ceems_compute_unit_gpu_index_flag gauge
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-61a65011-6571-a6d2-5ab8-66cbb6f7f9c3/",hindex="/gpu-1",hostname="",index="1",manager="slurm",uuid="1009250"} 1
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-956348bc-d43d-23ed-53d4-857749fa2b67/1",hindex="/gpu-2",hostname="",index="2",manager="slurm",uuid="1009248"} 0.6
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-956348bc-d43d-23ed-53d4-857749fa2b67/5",hindex="/gpu-3",hostname="",index="3",manager="slurm",uuid="1009248"} 0.2
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-f124aa59-d406-d45b-9481-8fcd694e6c9e/",hindex="/gpu-0",hostname="",index="0",manager="slurm",uuid="1009249"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="GPU-61a65011-6571-a6d2-5ab8-66cbb6f7f9c3",hindex="/gpu-1",hostname="",index="1",manager="slurm",uuid="1009250"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="GPU-f124aa59-d406-d45b-9481-8fcd694e6c9e",hindex="/gpu-0",hostname="",index="0",manager="slurm",uuid="1009249"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="1",gpuuuid="GPU-956348bc-d43d-23ed-53d4-857749fa2b67",hindex="/gpu-2",hostname="",index="2",manager="slurm",uuid="1009248"} 0.6
+ceems_compute_unit_gpu_index_flag{gpuiid="5",gpuuuid="GPU-956348bc-d43d-23ed-53d4-857749fa2b67",hindex="/gpu-3",hostname="",index="3",manager="slurm",uuid="1009248"} 0.2
 # HELP ceems_compute_unit_memory_cache_bytes Memory cache used in bytes
 # TYPE ceems_compute_unit_memory_cache_bytes gauge
 ceems_compute_unit_memory_cache_bytes{hostname="",manager="slurm",uuid="1009248"} 2.1086208e+07

--- a/pkg/collector/testdata/output/exporter/e2e-test-cgroupsv2-all-metrics-output.txt
+++ b/pkg/collector/testdata/output/exporter/e2e-test-cgroupsv2-all-metrics-output.txt
@@ -20,10 +20,10 @@ ceems_compute_unit_cpus{hostname="",manager="slurm",uuid="1009249"} 2
 ceems_compute_unit_cpus{hostname="",manager="slurm",uuid="1009250"} 2
 # HELP ceems_compute_unit_gpu_index_flag A value > 0 indicates the job using current GPU
 # TYPE ceems_compute_unit_gpu_index_flag gauge
-ceems_compute_unit_gpu_index_flag{gpuuuid="20170000800c/",hindex="/gpu-0",hostname="",index="0",manager="slurm",uuid="1009249"} 1
-ceems_compute_unit_gpu_index_flag{gpuuuid="20170003580c/",hindex="/gpu-1",hostname="",index="1",manager="slurm",uuid="1009250"} 1
-ceems_compute_unit_gpu_index_flag{gpuuuid="20170005280c/",hindex="/gpu-3",hostname="",index="3",manager="slurm",uuid="1009248"} 1
-ceems_compute_unit_gpu_index_flag{gpuuuid="20180003050c/",hindex="/gpu-2",hostname="",index="2",manager="slurm",uuid="1009248"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="20170000800c",hindex="/gpu-0",hostname="",index="0",manager="slurm",uuid="1009249"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="20170003580c",hindex="/gpu-1",hostname="",index="1",manager="slurm",uuid="1009250"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="20170005280c",hindex="/gpu-3",hostname="",index="3",manager="slurm",uuid="1009248"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="20180003050c",hindex="/gpu-2",hostname="",index="2",manager="slurm",uuid="1009248"} 1
 # HELP ceems_compute_unit_memory_cache_bytes Memory cache used in bytes
 # TYPE ceems_compute_unit_memory_cache_bytes gauge
 ceems_compute_unit_memory_cache_bytes{hostname="",manager="slurm",uuid="1009248"} 0

--- a/pkg/collector/testdata/output/exporter/e2e-test-cgroupsv2-amd-ipmitool-output.txt
+++ b/pkg/collector/testdata/output/exporter/e2e-test-cgroupsv2-amd-ipmitool-output.txt
@@ -15,10 +15,10 @@ ceems_compute_unit_cpus{hostname="",manager="slurm",uuid="1009249"} 2
 ceems_compute_unit_cpus{hostname="",manager="slurm",uuid="1009250"} 2
 # HELP ceems_compute_unit_gpu_index_flag A value > 0 indicates the job using current GPU
 # TYPE ceems_compute_unit_gpu_index_flag gauge
-ceems_compute_unit_gpu_index_flag{gpuuuid="20170000800c/",hindex="/gpu-0",hostname="",index="0",manager="slurm",uuid="1009249"} 1
-ceems_compute_unit_gpu_index_flag{gpuuuid="20170003580c/",hindex="/gpu-1",hostname="",index="1",manager="slurm",uuid="1009250"} 1
-ceems_compute_unit_gpu_index_flag{gpuuuid="20170005280c/",hindex="/gpu-3",hostname="",index="3",manager="slurm",uuid="1009248"} 1
-ceems_compute_unit_gpu_index_flag{gpuuuid="20180003050c/",hindex="/gpu-2",hostname="",index="2",manager="slurm",uuid="1009248"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="20170000800c",hindex="/gpu-0",hostname="",index="0",manager="slurm",uuid="1009249"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="20170003580c",hindex="/gpu-1",hostname="",index="1",manager="slurm",uuid="1009250"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="20170005280c",hindex="/gpu-3",hostname="",index="3",manager="slurm",uuid="1009248"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="20180003050c",hindex="/gpu-2",hostname="",index="2",manager="slurm",uuid="1009248"} 1
 # HELP ceems_compute_unit_memory_cache_bytes Memory cache used in bytes
 # TYPE ceems_compute_unit_memory_cache_bytes gauge
 ceems_compute_unit_memory_cache_bytes{hostname="",manager="slurm",uuid="1009248"} 0

--- a/pkg/collector/testdata/output/exporter/e2e-test-cgroupsv2-libvirt-output.txt
+++ b/pkg/collector/testdata/output/exporter/e2e-test-cgroupsv2-libvirt-output.txt
@@ -48,12 +48,12 @@ ceems_compute_unit_cpus{hostname="",manager="libvirt",uuid="57f2d45e-8ddf-4338-9
 ceems_compute_unit_cpus{hostname="",manager="libvirt",uuid="b674a0a2-c300-4dc6-8c9c-65df16da6d69"} 2
 # HELP ceems_compute_unit_gpu_index_flag A value > 0 indicates running instance using current GPU
 # TYPE ceems_compute_unit_gpu_index_flag gauge
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-61a65011-6571-a64n-5ab8-66cbb6f7f9c3/",hindex="/gpu-9",hostname="",index="9",manager="libvirt",uuid="2896bdd5-dbc2-4339-9d8e-ddd838bf35d3"} 1
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-61a65011-6571-a6d2-5ab8-66cbb6f7f9c3/",hindex="/gpu-1",hostname="",index="1",manager="libvirt",uuid="57f2d45e-8ddf-4338-91df-62d0044ff1b5"} 1
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-61a65011-6571-a6d2-5th8-66cbb6f7f9c3/",hindex="/gpu-8",hostname="",index="8",manager="libvirt",uuid="57f2d45e-8ddf-4338-91df-62d0044ff1b5"} 1
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-6cc98505-fdde-461e-a93c-6935fba45a27/",hindex="/gpu-11",hostname="",index="11",manager="libvirt",uuid="2896bdd5-dbc2-4339-9d8e-ddd838bf35d3"} 1
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-956348bc-d43d-23ed-53d4-857749fa2b67/5",hindex="/gpu-3",hostname="",index="3",manager="libvirt",uuid="b674a0a2-c300-4dc6-8c9c-65df16da6d69"} 0.1
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-f124aa59-d406-d45b-9481-8fcd694e6c9e/",hindex="/gpu-0",hostname="",index="0",manager="libvirt",uuid="b674a0a2-c300-4dc6-8c9c-65df16da6d69"} 0.5
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="GPU-61a65011-6571-a64n-5ab8-66cbb6f7f9c3",hindex="/gpu-9",hostname="",index="9",manager="libvirt",uuid="2896bdd5-dbc2-4339-9d8e-ddd838bf35d3"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="GPU-61a65011-6571-a6d2-5ab8-66cbb6f7f9c3",hindex="/gpu-1",hostname="",index="1",manager="libvirt",uuid="57f2d45e-8ddf-4338-91df-62d0044ff1b5"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="GPU-61a65011-6571-a6d2-5th8-66cbb6f7f9c3",hindex="/gpu-8",hostname="",index="8",manager="libvirt",uuid="57f2d45e-8ddf-4338-91df-62d0044ff1b5"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="GPU-6cc98505-fdde-461e-a93c-6935fba45a27",hindex="/gpu-11",hostname="",index="11",manager="libvirt",uuid="2896bdd5-dbc2-4339-9d8e-ddd838bf35d3"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="GPU-f124aa59-d406-d45b-9481-8fcd694e6c9e",hindex="/gpu-0",hostname="",index="0",manager="libvirt",uuid="b674a0a2-c300-4dc6-8c9c-65df16da6d69"} 0.5
+ceems_compute_unit_gpu_index_flag{gpuiid="5",gpuuuid="GPU-956348bc-d43d-23ed-53d4-857749fa2b67",hindex="/gpu-3",hostname="",index="3",manager="libvirt",uuid="b674a0a2-c300-4dc6-8c9c-65df16da6d69"} 0.1
 # HELP ceems_compute_unit_memory_cache_bytes Memory cache used in bytes
 # TYPE ceems_compute_unit_memory_cache_bytes gauge
 ceems_compute_unit_memory_cache_bytes{hostname="",manager="libvirt",uuid="2896bdd5-dbc2-4339-9d8e-ddd838bf35d3"} 0

--- a/pkg/collector/testdata/output/exporter/e2e-test-cgroupsv2-nvidia-gpu-reordering.txt
+++ b/pkg/collector/testdata/output/exporter/e2e-test-cgroupsv2-nvidia-gpu-reordering.txt
@@ -15,10 +15,10 @@ ceems_compute_unit_cpus{hostname="",manager="slurm",uuid="1009249"} 2
 ceems_compute_unit_cpus{hostname="",manager="slurm",uuid="1009250"} 2
 # HELP ceems_compute_unit_gpu_index_flag A value > 0 indicates the job using current GPU
 # TYPE ceems_compute_unit_gpu_index_flag gauge
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-61a65011-6571-a64n-5ab8-66cbb6f7f9c3/",hindex="/gpu-3",hostname="",index="3",manager="slurm",uuid="1009248"} 1
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-61a65011-6571-a6d2-5ab8-66cbb6f7f9c3/",hindex="/gpu-1",hostname="",index="1",manager="slurm",uuid="1009250"} 1
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-61a65011-6571-a6d2-5th8-66cbb6f7f9c3/",hindex="/gpu-2",hostname="",index="2",manager="slurm",uuid="1009248"} 1
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-f124aa59-d406-d45b-9481-8fcd694e6c9e/",hindex="/gpu-0",hostname="",index="0",manager="slurm",uuid="1009249"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="GPU-61a65011-6571-a64n-5ab8-66cbb6f7f9c3",hindex="/gpu-3",hostname="",index="3",manager="slurm",uuid="1009248"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="GPU-61a65011-6571-a6d2-5ab8-66cbb6f7f9c3",hindex="/gpu-1",hostname="",index="1",manager="slurm",uuid="1009250"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="GPU-61a65011-6571-a6d2-5th8-66cbb6f7f9c3",hindex="/gpu-2",hostname="",index="2",manager="slurm",uuid="1009248"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="GPU-f124aa59-d406-d45b-9481-8fcd694e6c9e",hindex="/gpu-0",hostname="",index="0",manager="slurm",uuid="1009249"} 1
 # HELP ceems_compute_unit_memory_cache_bytes Memory cache used in bytes
 # TYPE ceems_compute_unit_memory_cache_bytes gauge
 ceems_compute_unit_memory_cache_bytes{hostname="",manager="slurm",uuid="1009248"} 0

--- a/pkg/collector/testdata/output/exporter/e2e-test-cgroupsv2-nvidia-ipmiutil-output.txt
+++ b/pkg/collector/testdata/output/exporter/e2e-test-cgroupsv2-nvidia-ipmiutil-output.txt
@@ -15,10 +15,10 @@ ceems_compute_unit_cpus{hostname="",manager="slurm",uuid="1009249"} 2
 ceems_compute_unit_cpus{hostname="",manager="slurm",uuid="1009250"} 2
 # HELP ceems_compute_unit_gpu_index_flag A value > 0 indicates the job using current GPU
 # TYPE ceems_compute_unit_gpu_index_flag gauge
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-61a65011-6571-a6d2-5ab8-66cbb6f7f9c3/",hindex="/gpu-1",hostname="",index="1",manager="slurm",uuid="1009250"} 1
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-956348bc-d43d-23ed-53d4-857749fa2b67/1",hindex="/gpu-2",hostname="",index="2",manager="slurm",uuid="1009248"} 0.6
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-956348bc-d43d-23ed-53d4-857749fa2b67/5",hindex="/gpu-3",hostname="",index="3",manager="slurm",uuid="1009248"} 0.2
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-f124aa59-d406-d45b-9481-8fcd694e6c9e/",hindex="/gpu-0",hostname="",index="0",manager="slurm",uuid="1009249"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="GPU-61a65011-6571-a6d2-5ab8-66cbb6f7f9c3",hindex="/gpu-1",hostname="",index="1",manager="slurm",uuid="1009250"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="GPU-f124aa59-d406-d45b-9481-8fcd694e6c9e",hindex="/gpu-0",hostname="",index="0",manager="slurm",uuid="1009249"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="1",gpuuuid="GPU-956348bc-d43d-23ed-53d4-857749fa2b67",hindex="/gpu-2",hostname="",index="2",manager="slurm",uuid="1009248"} 0.6
+ceems_compute_unit_gpu_index_flag{gpuiid="5",gpuuuid="GPU-956348bc-d43d-23ed-53d4-857749fa2b67",hindex="/gpu-3",hostname="",index="3",manager="slurm",uuid="1009248"} 0.2
 # HELP ceems_compute_unit_memory_cache_bytes Memory cache used in bytes
 # TYPE ceems_compute_unit_memory_cache_bytes gauge
 ceems_compute_unit_memory_cache_bytes{hostname="",manager="slurm",uuid="1009248"} 0

--- a/pkg/collector/testdata/output/exporter/e2e-test-cgroupsv2-procfs-output.txt
+++ b/pkg/collector/testdata/output/exporter/e2e-test-cgroupsv2-procfs-output.txt
@@ -15,10 +15,10 @@ ceems_compute_unit_cpus{hostname="",manager="slurm",uuid="1009249"} 2
 ceems_compute_unit_cpus{hostname="",manager="slurm",uuid="1009250"} 2
 # HELP ceems_compute_unit_gpu_index_flag A value > 0 indicates the job using current GPU
 # TYPE ceems_compute_unit_gpu_index_flag gauge
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-61a65011-6571-a6d2-5ab8-66cbb6f7f9c3/",hindex="/gpu-1",hostname="",index="1",manager="slurm",uuid="1009250"} 1
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-956348bc-d43d-23ed-53d4-857749fa2b67/1",hindex="/gpu-2",hostname="",index="2",manager="slurm",uuid="1009248"} 0.6
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-956348bc-d43d-23ed-53d4-857749fa2b67/5",hindex="/gpu-3",hostname="",index="3",manager="slurm",uuid="1009248"} 0.2
-ceems_compute_unit_gpu_index_flag{gpuuuid="GPU-f124aa59-d406-d45b-9481-8fcd694e6c9e/",hindex="/gpu-0",hostname="",index="0",manager="slurm",uuid="1009249"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="GPU-61a65011-6571-a6d2-5ab8-66cbb6f7f9c3",hindex="/gpu-1",hostname="",index="1",manager="slurm",uuid="1009250"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="",gpuuuid="GPU-f124aa59-d406-d45b-9481-8fcd694e6c9e",hindex="/gpu-0",hostname="",index="0",manager="slurm",uuid="1009249"} 1
+ceems_compute_unit_gpu_index_flag{gpuiid="1",gpuuuid="GPU-956348bc-d43d-23ed-53d4-857749fa2b67",hindex="/gpu-2",hostname="",index="2",manager="slurm",uuid="1009248"} 0.6
+ceems_compute_unit_gpu_index_flag{gpuiid="5",gpuuuid="GPU-956348bc-d43d-23ed-53d4-857749fa2b67",hindex="/gpu-3",hostname="",index="3",manager="slurm",uuid="1009248"} 0.2
 # HELP ceems_compute_unit_memory_cache_bytes Memory cache used in bytes
 # TYPE ceems_compute_unit_memory_cache_bytes gauge
 ceems_compute_unit_memory_cache_bytes{hostname="",manager="slurm",uuid="1009248"} 0

--- a/website/cspell.json
+++ b/website/cspell.json
@@ -61,7 +61,8 @@
         "ISDM",
         "MESO",
         "mgmt",
-        "HWMON"
+        "HWMON",
+        "gpuiid"
     ],
     // flagWords - list of words to be always considered incorrect
     // This is useful for offensive words and common spelling errors.

--- a/website/docs/configuration/prometheus.md
+++ b/website/docs/configuration/prometheus.md
@@ -16,10 +16,19 @@ contains NVIDIA GPUs:
 scrape_configs:
   - job_name: "gpu-node-group"
     metric_relabel_configs:
-      - source_labels: [UUID,GPU_I_ID]
-        separator: '/'
+      - source_labels: [UUID]
+        regex: (.*)
         target_label: gpuuuid
+        replacement: $1
+        action: replace
+      - source_labels: [GPU_I_ID]
+        regex: (.*)
+        target_label: gpuiid
+        replacement: $1
+        action: replace
       - regex: UUID
+        action: labeldrop
+      - regex: GPU_I_ID
         action: labeldrop
       - regex: modelName
         action: labeldrop
@@ -27,7 +36,7 @@ scrape_configs:
       - targets: ["http://gpu-0:9400", "http://gpu-1:9400", ...]
 ```
 
-The `metric_relabel_configs` is merges labels `UUID` and `GPU_I_ID` which are
-the UUID and MIG instance ID of GPU, respectively and sets it to `gpuuuid`
-which is compatible with CEEMS exporter. Moreover the config also drops unused
-`UUID` and `modelName` labels to reduce storage and cardinality.
+The `metric_relabel_configs` renames `UUID` and `GPU_I_ID` which are
+the UUID and MIG instance ID of GPU, respectively and sets it to `gpuuuid` and
+`gpuiid` which are compatible with CEEMS exporter. Moreover the config also drops unused
+`UUID`, `GPU_I_ID` and `modelName` labels to reduce storage and cardinality.


### PR DESCRIPTION
* We were merging GPU UUID with MIG Instance label. This is not very nice as GPU UUIDs will always have trailing backslashes when MIG is not enabled. We refactor this by exposing them as separate labels