### PR TITLE
Better usage of bpf LRU hash maps

### DIFF
--- a/pkg/collector/bpf/include/compiler.h
+++ b/pkg/collector/bpf/include/compiler.h
@@ -11,7 +11,11 @@
  * 
 */
 #ifndef MAX_MAP_ENTRIES
-#define MAX_MAP_ENTRIES 4096
+#define MAX_MAP_ENTRIES 16384
+#endif
+
+#ifndef MAX_MOUNT_SIZE
+#define MAX_MOUNT_SIZE 64
 #endif
 
 #define FUNC_INLINE static inline __attribute__((always_inline))

--- a/pkg/collector/bpf/network/bpf_network.h
+++ b/pkg/collector/bpf/network/bpf_network.h
@@ -17,6 +17,11 @@ enum net_mode {
 	MODE_EGRESS
 };
 
+/* 
+ * DO NOT USE BPF_F_NO_COMMON_LRU flag while creating maps.
+ * See vfs/bpf_vfs.h file for explanations.
+*/
+
 /* network related event struct */
 struct net_event {
 	__u32 cid; /* cgroup ID */
@@ -36,7 +41,6 @@ struct {
 	__uint(max_entries, MAX_MAP_ENTRIES);
 	__type(key, struct net_event); /* Key is the net_event struct */
 	__type(value, struct net_stats);
-	__uint(map_flags, BPF_F_NO_COMMON_LRU);
 } ingress_accumulator SEC(".maps");
 
 /* Map to track ingress events */
@@ -45,7 +49,6 @@ struct {
 	__uint(max_entries, MAX_MAP_ENTRIES);
 	__type(key, struct net_event); /* Key is the net_event struct */
 	__type(value, struct net_stats);
-	__uint(map_flags, BPF_F_NO_COMMON_LRU);
 } egress_accumulator SEC(".maps");
 
 /* Map to track retransmission events */
@@ -54,7 +57,6 @@ struct {
 	__uint(max_entries, MAX_MAP_ENTRIES);
 	__type(key, struct net_event); /* Key is the net_event struct */
 	__type(value, struct net_stats);
-	__uint(map_flags, BPF_F_NO_COMMON_LRU);
 } retrans_accumulator SEC(".maps");
 
 /**


### PR DESCRIPTION
* Using BPF_F_NO_COMMON_LRU flag while map creation leads to have LRU maps per CPU and eviction is handled by individual CPU. We noticed that on JZ, this leads to non LRU behaviour where active job entries are evicted which results in loss of information.

* This can be due to lot of factors like small map size and maintaining per CPU maps. This commit increases map size to 16k which is the range these maps are meant to be used. We also removed BPF_F_NO_COMMON_LRU flag to keep global LRU map which should give us more LRU behaviour. With the basic benchmarks, we noticed that removing this flag has no impact of per bpf call overhead.

* We also included utility functions to ignore all the pseudo file system mounts like /proc, /sys, /dev in VFS maps. This will avoid updating bpf maps with "irrelevant" data and at the same time maps will have more entries to track interested cgroups.