### PR TITLE
Harden redfish proxy app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ website/static/repos
 
 # Do not ignore k8s test files
 !pkg/collector/testdata/k8s/*.json
+
+# Ignore assets for mock_servers
+scripts/mock_servers/assets

--- a/Makefile.common
+++ b/Makefile.common
@@ -222,6 +222,11 @@ ifeq ($(CGO_BUILD), 1)
 	$(SWAG) fmt -d $(SWAGGER_DIR) -g $(SWAGGER_MAIN)
 endif
 	@echo ">> building test binaries"
+	mkdir -p scripts/mock_servers/assets
+	cp -r pkg/collector/testdata/redfish scripts/mock_servers/assets
+	cp -r pkg/collector/testdata/k8s scripts/mock_servers/assets
+	cp -r pkg/lb/testdata/pyroscope scripts/mock_servers/assets
+	cp -r pkg/api/testdata/openstack scripts/mock_servers/assets
 	$(PROMU_GO_TEST) build --prefix $(PREFIX) $(PROMU_BINARIES)
 ifeq ($(CGO_BUILD), 0)
 	$(PROMU_CGO_TEST) build --prefix $(PREFIX) $(PROMU_BINARIES)

--- a/build/config/ceems_exporter/redfish_exporter_config.yml
+++ b/build/config/ceems_exporter/redfish_exporter_config.yml
@@ -67,9 +67,27 @@ redfish_web_config: {}
   # #
   # password: supersecret
 
+  # # When TLS is enabled on Redfish server or Redfish Proxy server,
+  # # use this to configure the TLS transport
+  # #
+  # # Ref: https://pkg.go.dev/github.com/prometheus/common@v0.63.0/config#TLSConfig
+  # #
+  # tls_config: {}
+
+  # # When Redfish Proxy is protected with an API token, use this section
+  # # to setup the autorization to proxy server. This is relevant in k8s
+  # # deployments where kube RBAC proxy is deployed along with redfish proxy
+  # # server to protect the access to proxy.
+  # #
+  # # Ref: https://pkg.go.dev/github.com/prometheus/common@v0.63.0/config#Authorization
+  # #
+  # authorization: {}
+
   # # If TLS is enabled on Redfish server or Redfish Proxy server 
   # # with self signed certificates, set it to true to skip TLS 
   # # certificate verification.
+  # #
+  # # Deprecated: Use `tls_config.insecure_skip_verify` instead
   # #
   # insecure_skip_verify: false
 

--- a/build/config/redfish_proxy/redfish_proxy.yml
+++ b/build/config/redfish_proxy/redfish_proxy.yml
@@ -5,8 +5,20 @@ redfish_config:
   # Redfish API server.
   #
   web:
+    # If Redfish targets are using TLS, use this section to
+    # configure the root CA when they are using self signed.
+    # Also it is possible to ignore certificate check by
+    # setting `insecure_skip_verify` to `true` in trusted
+    # deployments.
+    #
+    # Ref: https://pkg.go.dev/github.com/prometheus/common@v0.63.0/config#TLSConfig
+    #
+    tls_config: {}
+    
     # If Redfish API servers are running with TLS enabled
     # and using self signed certificates, set `insecure_skip_verify`
     # to `true` to skip TLS certifcate verification
+    #
+    # Deprecated: Use `tls_config.insecure_skip_verify` instead
     #
     insecure_skip_verify: false 

--- a/build/scripts/liveness-probe.sh
+++ b/build/scripts/liveness-probe.sh
@@ -58,7 +58,7 @@ fi
 # Check if HTTP server is responding
 if ! [ -z "${port}" ]; then
     if ! curl -sf "http://localhost:${port}/health" > /dev/null; then
-        echo "App at port ${port} is not responding"
+        echo "${app} at port ${port} is not responding"
         exit 1
     fi
 fi

--- a/cmd/redfish_proxy/server_test.go
+++ b/cmd/redfish_proxy/server_test.go
@@ -7,12 +7,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/mahendrapaipuri/ceems/internal/common"
+	"github.com/prometheus/common/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -50,7 +53,10 @@ func TestNewRedfishProxyServerWithTargets(t *testing.T) {
 		Redfish: &Redfish{
 			Config: struct {
 				Web struct {
-					Insecure bool `yaml:"insecure_skip_verify"`
+					HTTPClientConfig          config.HTTPClientConfig `yaml:",inline"`
+					AllowedAPIResources       []string                `yaml:"allowed_api_resources"`
+					Insecure                  bool                    `yaml:"insecure_skip_verify"`
+					allowedAPIResourcesRegexp *regexp.Regexp
 				} `yaml:"web"`
 				Targets []Target `yaml:"targets"`
 			}{
@@ -76,7 +82,8 @@ func TestNewRedfishProxyServerWithTargets(t *testing.T) {
 	config.Web.Addresses = []string{":" + strconv.FormatInt(int64(p), 10)}
 
 	// New instance
-	server := NewRedfishProxyServer(config)
+	server, err := NewRedfishProxyServer(config)
+	require.NoError(t, err)
 
 	// Start server
 	go func() {
@@ -129,14 +136,21 @@ func TestNewRedfishProxyServerWithWebConfig(t *testing.T) {
 		Redfish: &Redfish{
 			Config: struct {
 				Web struct {
-					Insecure bool `yaml:"insecure_skip_verify"`
+					HTTPClientConfig          config.HTTPClientConfig `yaml:",inline"`
+					AllowedAPIResources       []string                `yaml:"allowed_api_resources"`
+					Insecure                  bool                    `yaml:"insecure_skip_verify"`
+					allowedAPIResourcesRegexp *regexp.Regexp
 				} `yaml:"web"`
 				Targets []Target `yaml:"targets"`
 			}{
 				Web: struct {
-					Insecure bool `yaml:"insecure_skip_verify"`
+					HTTPClientConfig          config.HTTPClientConfig `yaml:",inline"`
+					AllowedAPIResources       []string                `yaml:"allowed_api_resources"`
+					Insecure                  bool                    `yaml:"insecure_skip_verify"`
+					allowedAPIResourcesRegexp *regexp.Regexp
 				}{
-					Insecure: true,
+					Insecure:                  true,
+					allowedAPIResourcesRegexp: regexp.MustCompile(strings.Join(defaultAllowedAPIResources, "|")),
 				},
 			},
 		},
@@ -150,7 +164,8 @@ func TestNewRedfishProxyServerWithWebConfig(t *testing.T) {
 	config.Web.Addresses = []string{":" + strconv.FormatInt(int64(p), 10)}
 
 	// New instance
-	server := NewRedfishProxyServer(config)
+	server, err := NewRedfishProxyServer(config)
+	require.NoError(t, err)
 
 	// Start server
 	go func() {
@@ -164,7 +179,7 @@ func TestNewRedfishProxyServerWithWebConfig(t *testing.T) {
 
 	// Make request to only 1st server
 	for i := range 2 {
-		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%d", p), nil) //nolint:noctx
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%d/redfish/v1/", p), nil) //nolint:noctx
 		require.NoError(t, err)
 
 		// Make second request without Redfish URL header and it should pass as we
@@ -184,5 +199,63 @@ func TestNewRedfishProxyServerWithWebConfig(t *testing.T) {
 
 		// Check the body if it has same IP set
 		assert.Equal(t, strings.Join([]string{remoteIPs[0]}, ","), string(bodyBytes))
+	}
+
+	// Make a request without redfishURL header and invalid remoteIP
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%d/redfish/v1/", p), nil) //nolint:noctx
+	require.NoError(t, err)
+
+	req.Header.Add(realIPHeaderName, "1.1.1.1")
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Check the body if it has same IP set
+	assert.Equal(t, 400, resp.StatusCode)
+
+	// Start a wait group
+	wg := sync.WaitGroup{}
+
+	// Use a channel to hand off the error
+	// Ref: https://github.com/ipfs/kubo/issues/2043#issuecomment-164136026
+	errs := make(chan error, 20*3)
+
+	// Make concurrent requests to detect data races
+	for i := range 20 {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%d/redfish/v1/", p), nil) //nolint:noctx
+			errs <- err
+
+			// Target ID
+			tid := i % len(targetURLs)
+
+			req.Header.Add(redfishURLHeaderName, "http://localhost:"+targetURLs[tid].Port())
+			req.Header.Add(realIPHeaderName, remoteIPs[tid])
+
+			resp, err := client.Do(req)
+			errs <- err
+			defer resp.Body.Close()
+
+			bodyBytes, err := io.ReadAll(resp.Body)
+			errs <- err
+
+			// Check the body if it has same IP set
+			assert.Equal(t, strings.Join([]string{remoteIPs[tid]}, ","), string(bodyBytes))
+		}()
+	}
+
+	// Wait for all requests to finish
+	wg.Wait()
+
+	// Check for any errs
+	// wait for all N to finish
+	for range 20 * 3 {
+		err := <-errs
+		require.NoError(t, err)
 	}
 }

--- a/pkg/collector/testdata/redfish/config.yml
+++ b/pkg/collector/testdata/redfish/config.yml
@@ -1,6 +1,6 @@
 ---
 redfish_web_config:
   protocol: http
-  host: localhost
+  hostname: localhost
   port: 5000
   use_session_token: true

--- a/pkg/lb/frontend/frontend_test.go
+++ b/pkg/lb/frontend/frontend_test.go
@@ -134,11 +134,20 @@ func TestNewFrontend(t *testing.T) {
 	lb, err := New(config)
 	require.NoError(t, err)
 
+	// Use a channel to hand off the error
+	// Ref: https://github.com/ipfs/kubo/issues/2043#issuecomment-164136026
+	errs := make(chan error, 1)
+
 	go func() {
-		lb.Start(t.Context())
+		err := lb.Start(t.Context())
+		errs <- err
 	}()
 
 	err = lb.Shutdown(t.Context())
+	require.NoError(t, err)
+
+	// Wait for it
+	err = <-errs
 	require.NoError(t, err)
 }
 

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -1243,9 +1243,9 @@ then
     waitport "${port}"
     for i in {0..9}
     do
-      get -H "X-Real-IP: 192.168.1.${i}" "127.0.0.1:${port}" >> "${fixture_output}"
+      get -H "X-Real-IP: 192.168.1.${i}" "127.0.0.1:${port}/redfish/v1/" >> "${fixture_output}"
     done
-    get -H "X-Redfish-Url: http://localhost:5000" "127.0.0.1:${port}" >> "${fixture_output}"
+    get -H "X-Redfish-Url: http://localhost:5000" "127.0.0.1:${port}/redfish/v1/" >> "${fixture_output}"
 
   elif [ "${scenario}" = "redfish-proxy-frontend-tls-backend-plain" ]
   then
@@ -1266,9 +1266,9 @@ then
     waitport "${port}"
     for i in {0..9}
     do
-      get -H "X-Real-IP: 192.168.1.${i}" "https://127.0.0.1:${port}" >> "${fixture_output}"
+      get -H "X-Real-IP: 192.168.1.${i}" "https://127.0.0.1:${port}/redfish/v1/" >> "${fixture_output}"
     done
-    get -H "X-Redfish-Url: http://localhost:5000" "https://127.0.0.1:${port}" >> "${fixture_output}"
+    get -H "X-Redfish-Url: http://localhost:5000" "https://127.0.0.1:${port}/redfish/v1/" >> "${fixture_output}"
 
   elif [ "${scenario}" = "redfish-proxy-frontend-plain-backend-tls" ]
   then
@@ -1288,9 +1288,9 @@ then
     waitport "${port}"
     for i in {0..9}
     do
-      get -H "X-Real-IP: 192.168.1.${i}" "127.0.0.1:${port}" >> "${fixture_output}"
+      get -H "X-Real-IP: 192.168.1.${i}" "127.0.0.1:${port}/redfish/v1/" >> "${fixture_output}"
     done
-    get -H "X-Redfish-Url: https://localhost:5005" "127.0.0.1:${port}" >> "${fixture_output}"
+    get -H "X-Redfish-Url: https://localhost:5005" "127.0.0.1:${port}/redfish/v1/" >> "${fixture_output}"
 
   elif [ "${scenario}" = "redfish-proxy-frontend-tls-backend-tls" ]
   then
@@ -1311,9 +1311,9 @@ then
     waitport "${port}"
     for i in {0..9}
     do
-      get -H "X-Real-IP: 192.168.1.${i}" "https://127.0.0.1:${port}" >> "${fixture_output}"
+      get -H "X-Real-IP: 192.168.1.${i}" "https://127.0.0.1:${port}/redfish/v1/" >> "${fixture_output}"
     done
-    get -H "X-Redfish-Url: https://localhost:5005" "https://127.0.0.1:${port}" >> "${fixture_output}"
+    get -H "X-Redfish-Url: https://localhost:5005" "https://127.0.0.1:${port}/redfish/v1/" >> "${fixture_output}"
 
   elif [ "${scenario}" = "redfish-proxy-targetless-frontend-plain-backend-plain" ]
   then
@@ -1330,7 +1330,7 @@ then
 
     sleep 5
     waitport "${port}"
-    get -H "X-Redfish-Url: http://localhost:5000" "http://127.0.0.1:${port}" >> "${fixture_output}"
+    get -H "X-Redfish-Url: http://localhost:5000" "http://127.0.0.1:${port}/redfish/v1/" >> "${fixture_output}"
   fi
 
 elif [[ "${scenario}" =~ ^"cacct" ]]

--- a/website/docs/configuration/ceems-exporter.md
+++ b/website/docs/configuration/ceems-exporter.md
@@ -421,9 +421,28 @@ redfish_web_config:
   #
   password: supersecret
 
+  # When TLS is enabled on Redfish server or Redfish Proxy server,
+  # use this to configure the TLS transport
+  #
+  # Ref: https://pkg.go.dev/github.com/prometheus/common@v0.63.0/config#TLSConfig
+  #
+  tls_config:
+    insecure_skip_verify: true
+
+  # When Redfish Proxy is protected with an API token, use this section
+  # to setup the autorization to proxy server. This is relevant in k8s
+  # deployments where kube RBAC proxy is deployed along with redfish proxy
+  # server to protect the access to proxy.
+  #
+  # Ref: https://pkg.go.dev/github.com/prometheus/common@v0.63.0/config#Authorization
+  #
+  authorization: {}
+
   # If TLS is enabled on Redfish server or Redfish Proxy server 
   # with self-signed certificates, set it to true to skip TLS 
   # certificate verification.
+  #
+  # Deprecated: Use `tls_config.insecure_skip_verify` instead
   #
   insecure_skip_verify: true
 
@@ -495,16 +514,28 @@ redfish_config:
   # Redfish API server.
   #
   web:
+    # If Redfish targets are using TLS, use this section to
+    # configure the root CA when they are using self signed.
+    # Also it is possible to ignore certificate check by
+    # setting `insecure_skip_verify` to `true` in trusted
+    # deployments.
+    #
+    # Ref: https://pkg.go.dev/github.com/prometheus/common@v0.63.0/config#TLSConfig
+    #
+    tls_config: {}
+
     # If Redfish API servers are running with TLS enabled
     # and using self-signed certificates, set `insecure_skip_verify`
     # to `true` to skip TLS certificate verification
+    #
+    # Deprecated: Use `tls_config.insecure_skip_verify` instead
     #
     insecure_skip_verify: false
 ```
 
 If the Redfish servers are running with TLS using self-signed certificates, provide
-a config file with `insecure_skip_verify` set to `true`. If that is not the case, the config
-file can be avoided.
+a config file with `tls_config.insecure_skip_verify` set to `true`. If that is not the case,
+the config file can be avoided.
 
 <!-- If there are multiple network interfaces with IP addresses on the compute nodes, it is
 **strongly advised to add entry for each IP address**. For instance, if a compute node


### PR DESCRIPTION
* Add configurable option to define a list of resources that should be allowed by the proxy. This ensures that the proxy clients will not be able to make DoS/DDoS attacks on BMC easily. Add `ErrorHandler` to server proxy to send a 400 response on all the errors on the request. If the requested resource is not in the defined list of resources, send a 401 response.

* Use HTTPClientConfig on both redfish proxy and redfish collector configs. This ensures that whole package stays consistent.

* Embed all the files of mock_servers in the app so that we can reuse it easily.

* Fix error handling in go routines in the unit tests  using channels