### PR TITLE
refactor: Rename config section names to be consistent across package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - run: go mod download
       - run: GOARCH=1 make clang
       - run: make
-      - run: CGO_BUILD=1 make
+      - run: CGO_APPS=1 make
   test-arm:
     executor: arm
     steps:
@@ -29,7 +29,7 @@ jobs:
       - run: uname -a
       - run: GOARCH=1 make clang
       - run: make
-      - run: CGO_BUILD=1 make
+      - run: CGO_APPS=1 make
   build:
     machine:
       image: ubuntu-2204:current
@@ -39,12 +39,12 @@ jobs:
       - prometheus/setup_environment
       # - run: docker run --privileged linuxkit/binfmt:af88a591f9cc896a52ce596b9cf7ca26a061ef97
       - run: promu --config .promu-go.yml crossbuild -v --parallelism $CIRCLE_NODE_TOTAL --parallelism-thread $CIRCLE_NODE_INDEX
-      # Replace default CGO_BUILD before we run CGO. There is no way to inject this env 
+      # Replace default CGO_APPS before we run CGO. There is no way to inject this env 
       # variable into golang-builder container. So we artificially replace the default
-      # CGO_BUILD variable in Makefile and run CGO promu
+      # CGO_APPS variable in Makefile and run CGO promu
       # Do not use CGO_ENABLED env var as golang-builder image will set this var by default to zer
       # and our override will not have any effect
-      - run: sed -i -e 's/CGO_BUILD               ?= 0/CGO_BUILD               ?= 1/g' Makefile
+      - run: sed -i -e 's/CGO_APPS               ?= 0/CGO_APPS               ?= 1/g' Makefile
       - run: promu --config .promu-cgo.yml crossbuild -v --parallelism $CIRCLE_NODE_TOTAL --parallelism-thread $CIRCLE_NODE_INDEX
       - persist_to_workspace:
           root: .

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,7 +59,7 @@ jobs:
         echo 'Building pure go binaries'
         make build
         echo 'Building cgo binaries'
-        CGO_BUILD=1 make build
+        CGO_APPS=1 make build
         # Run extractor
         "${CODEQL_EXTRACTOR_GO_ROOT}/tools/linux64/go-extractor" ./...
 

--- a/.github/workflows/step_build.yml
+++ b/.github/workflows/step_build.yml
@@ -28,7 +28,7 @@ jobs:
         run: make crossbuild-test
 
       - name: Cross compile CGo packages
-        run: CGO_BUILD=1 make crossbuild-test
+        run: CGO_APPS=1 make crossbuild-test
 
       - name: Upload go build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/step_cross-build.yml
+++ b/.github/workflows/step_cross-build.yml
@@ -32,7 +32,7 @@ jobs:
         run: make crossbuild
 
       - name: Cross compile CGo packages
-        run: CGO_BUILD=1 make crossbuild
+        run: CGO_APPS=1 make crossbuild
       
       - name: Create tarballs and checksums
         run: |

--- a/.github/workflows/step_tests-e2e.yml
+++ b/.github/workflows/step_tests-e2e.yml
@@ -24,4 +24,4 @@ jobs:
         run: make test-e2e
 
       - name: Run e2e tests for CGo packages
-        run: CGO_BUILD=1 make test-e2e
+        run: CGO_APPS=1 make test-e2e

--- a/.github/workflows/step_tests-unit.yml
+++ b/.github/workflows/step_tests-unit.yml
@@ -27,7 +27,7 @@ jobs:
         run: make test
 
       - name: Run unit tests for CGo packages
-        run: CGO_BUILD=1 make test
+        run: CGO_APPS=1 make test
 
       - name: Merge coverage files
         run: |

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ CGROUPS_MODE            ?= $([ $(stat -fc %T /sys/fs/cgroup/) = "cgroup2fs" ] &&
 
 STATICCHECK_IGNORE =
 
-CGO_BUILD               ?= 0
+CGO_APPS                ?= 0
 RELEASE_BUILD           ?= 0
 
 # Swagger docs
@@ -51,7 +51,7 @@ test-flags := -covermode=atomic -race
 
 # Use CGO for api and GO for ceems_exporter.
 PROMU_TEST_CONF ?= .promu/.promu-go-test.yml
-ifeq ($(CGO_BUILD), 1)
+ifeq ($(CGO_APPS), 1)
 	PROMU_CONF ?= .promu/.promu-cgo.yml
 	pkgs := ./pkg/sqlite3 ./pkg/api/cli \
 			./pkg/api/db ./pkg/api/db/migrator ./pkg/api/helper \
@@ -103,7 +103,7 @@ e2e-out = pkg/collector/testdata/output
 cross-test = skip-test-32bit
 define goarch_pair
 	ifeq ($$(GOHOSTOS), linux)
-		ifndef CGO_BUILD
+		ifndef CGO_APPS
 			ifeq ($$(GOHOSTARCH), $1)
 				GOARCH_CROSS = $2
 				cross-test = test-32bit
@@ -152,7 +152,7 @@ update_testdata:
 	./scripts/ttar -C pkg/collector/testdata -c -f pkg/collector/testdata/sys.ttar sys
 	./scripts/ttar -C pkg/collector/testdata -c -f pkg/collector/testdata/proc.ttar proc
 
-ifeq ($(CGO_BUILD), 0)
+ifeq ($(CGO_APPS), 0)
 .PHONY: test-e2e
 test-e2e: $(PROMTOOL) build pkg/collector/testdata/sys/.unpacked pkg/collector/testdata/proc/.unpacked
 	@echo ">> running end-to-end tests"
@@ -230,7 +230,7 @@ test-e2e: $(PROMTOOL) build pkg/collector/testdata/sys/.unpacked pkg/collector/t
 	@env GOBIN=$(FIRST_GOPATH) ./scripts/e2e-test.sh -s lb-auth
 endif
 
-ifeq ($(CGO_BUILD), 0)
+ifeq ($(CGO_APPS), 0)
 .PHONY: test-e2e-update
 test-e2e-update: build pkg/collector/testdata/sys/.unpacked pkg/collector/testdata/proc/.unpacked
 	@echo ">> updating end-to-end tests outputs"

--- a/Makefile.common
+++ b/Makefile.common
@@ -216,7 +216,7 @@ common-unused:
 .PHONY: common-build
 common-build: promu swag bpf
 ifeq ($(RELEASE_BUILD), 0)
-ifeq ($(CGO_BUILD), 1)
+ifeq ($(CGO_APPS), 1)
 	@echo ">> updating swagger docs"
 	$(SWAG) init -d $(SWAGGER_DIR) -g $(SWAGGER_MAIN) -o $(SWAGGER_DIR)/docs --pd --quiet
 	$(SWAG) fmt -d $(SWAGGER_DIR) -g $(SWAGGER_MAIN)
@@ -228,7 +228,7 @@ endif
 	cp -r pkg/lb/testdata/pyroscope scripts/mock_servers/assets
 	cp -r pkg/api/testdata/openstack scripts/mock_servers/assets
 	$(PROMU_GO_TEST) build --prefix $(PREFIX) $(PROMU_BINARIES)
-ifeq ($(CGO_BUILD), 0)
+ifeq ($(CGO_APPS), 0)
 	$(PROMU_CGO_TEST) build --prefix $(PREFIX) $(PROMU_BINARIES)
 endif
 endif
@@ -295,7 +295,7 @@ updatevars:
 	@echo ">> updating makefile vars in-place"
 	sed -i -e 's/RELEASE_BUILD           ?= 0/RELEASE_BUILD           ?= 1/g' Makefile
 	sed -i -e 's/osusergo, netgo, static_build, test/osusergo, netgo, static_build/g' .promu/.promu-go.yml
-	sed -i -e 's/CGO_BUILD               ?= 0/CGO_BUILD               ?= $(CGO_BUILD)/g' Makefile
+	sed -i -e 's/CGO_APPS               ?= 0/CGO_APPS               ?= $(CGO_APPS)/g' Makefile
 
 .PHONY: promu
 promu: $(PROMU)
@@ -327,8 +327,8 @@ $(CT):
 
 # Build bpf assets
 .PHONY: bpf
-# Build bpf assets only when CGO_BUILD=0
-ifeq ($(CGO_BUILD), 0)
+# Build bpf assets only when CGO_APPS=0
+ifeq ($(CGO_APPS), 0)
 bpf: clang bpfclean
 	@echo ">> building bpf assets using clang"
 	$(MAKE) -C ./pkg/collector/bpf
@@ -358,7 +358,7 @@ endif
 swag: $(SWAG)
 $(SWAG):
 ifeq ($(RELEASE_BUILD), 0)
-ifeq ($(CGO_BUILD), 1)
+ifeq ($(CGO_APPS), 1)
 	$(GO) install github.com/swaggo/swag/cmd/swag@v1.16.3
 endif
 endif

--- a/build/config/ceems_exporter/redfish_exporter_config.yml
+++ b/build/config/ceems_exporter/redfish_exporter_config.yml
@@ -2,7 +2,7 @@
 # This is a sample configuration file for redfish collector
 # to fetch the power consumption readings from redfish API server
 #
-redfish_web_config: {}
+redfish_web: {}
   # # Protocol of Redfish API server. Possible values are http, https
   # #
   # protocol: https

--- a/build/config/redfish_proxy/redfish_proxy.yml
+++ b/build/config/redfish_proxy/redfish_proxy.yml
@@ -1,6 +1,6 @@
 ---
 # Conifguration file for redfish_proxy app
-redfish_config:
+redfish_proxy:
   # This section must provide web configuration of
   # Redfish API server.
   #

--- a/cmd/redfish_proxy/main_test.go
+++ b/cmd/redfish_proxy/main_test.go
@@ -58,12 +58,25 @@ func TestConfigValidation(t *testing.T) {
 			name: "valid config with web section",
 			content: `
 ---
-redfish_config:
+redfish_proxy:
   web:
     insecure_skip_verify: true`,
 		},
 		{
 			name: "valid config with web and targets section",
+			content: `
+---
+redfish_proxy:
+  web:
+    insecure_skip_verify: true
+  targets:
+    - host_ip_addrs:
+        - 192.168.1.1
+        - 192.168.1.2
+      url: http://172.134.1.1:80`,
+		},
+		{
+			name: "valid deprecated config with web and targets section",
 			content: `
 ---
 redfish_config:
@@ -80,7 +93,7 @@ redfish_config:
 			err:  true,
 			content: `
 ---
-redfish_config:
+redfish_proxy:
   web:
     insecure_skip_verify: true
   targets:

--- a/cmd/redfish_proxy/testdata/config-plain.yml
+++ b/cmd/redfish_proxy/testdata/config-plain.yml
@@ -1,5 +1,5 @@
 ---
-redfish_config:
+redfish_proxy:
   web:
     insecure_skip_verify: false
 

--- a/pkg/collector/testdata/redfish/config.yml
+++ b/pkg/collector/testdata/redfish/config.yml
@@ -1,5 +1,5 @@
 ---
-redfish_web_config:
+redfish_web:
   protocol: http
   hostname: localhost
   port: 5000

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -527,7 +527,7 @@ then
         --collector.ipmi_dcmi \
         --collector.ipmi_dcmi.test-mode \
         --collector.redfish \
-        --collector.redfish.web-config="pkg/collector/testdata/redfish/config.yml" \
+        --collector.redfish.web-config-file="pkg/collector/testdata/redfish/config.yml" \
         --collector.netdev \
         --collector.netdev.device-include="eth0" \
         --web.listen-address "127.0.0.1:${port}" \
@@ -627,7 +627,7 @@ then
         --collector.ipmi.dcmi.cmd="pkg/collector/testdata/ipmi/capmc/capmc" \
         --collector.ipmi_dcmi.test-mode \
         --collector.redfish \
-        --collector.redfish.web-config="pkg/collector/testdata/redfish/config.yml" \
+        --collector.redfish.web-config-file="pkg/collector/testdata/redfish/config.yml" \
         --collector.cray_pm_counters \
         --collector.empty-hostname-label \
         --web.listen-address "127.0.0.1:${port}" \
@@ -712,7 +712,7 @@ then
         --collector.ipmi.dcmi.cmd="pkg/collector/testdata/ipmi/capmc/capmc" \
         --collector.ipmi_dcmi.test-mode \
         --collector.redfish \
-        --collector.redfish.web-config="pkg/collector/testdata/redfish/config.yml" \
+        --collector.redfish.web-config-file="pkg/collector/testdata/redfish/config.yml" \
         --collector.empty-hostname-label \
         --web.listen-address "127.0.0.1:${port}" \
         --web.disable-exporter-metrics \
@@ -799,7 +799,7 @@ then
         --collector.k8s.kubelet-socket-file="${CEEMS_KUBELET_SOCKET_DIR}/amd/kubelet.sock" \
         --collector.cgroups.force-version="v1" \
         --collector.redfish \
-        --collector.redfish.web-config="pkg/collector/testdata/redfish/config.yml" \
+        --collector.redfish.web-config-file="pkg/collector/testdata/redfish/config.yml" \
         --collector.empty-hostname-label \
         --web.listen-address "127.0.0.1:${port}" \
         --web.disable-exporter-metrics \
@@ -1460,7 +1460,7 @@ then
         --collector.slurm \
         --collector.gpu.type="nogpu" \
         --collector.redfish \
-        --collector.redfish.web-config="pkg/collector/testdata/redfish/config.yml" \
+        --collector.redfish.web-config-file="pkg/collector/testdata/redfish/config.yml" \
         --collector.empty-hostname-label \
         --web.listen-address "127.0.0.1:9012" \
         --web.disable-exporter-metrics \

--- a/website/docs/configuration/ceems-exporter.md
+++ b/website/docs/configuration/ceems-exporter.md
@@ -352,11 +352,21 @@ ceems_exporter --collector.redfish
 ```
 
 A YAML configuration file containing the Redfish's API server details must be provided
-to the CLI flag `--collector.redfish.web-config`. A sample file is shown as follows:
+to the CLI flag `--collector.redfish.web-config-file`. A sample file is shown as follows:
+
+:::warning[WARNING]
+
+CLI flag `--collector.redfish.web-config` has been deprecated and will be removed in the
+next stable release. The flag will be now available under `--collector.redfish.web-config-file`.
+
+Similarly, the web configuration for Redfish must be now provided under `redfish_web` section
+instead of `redfish_web_config` which has also been deprecated.
+
+:::
 
 ```yaml
 ---
-redfish_web_config:
+redfish_web:
   # Protocol of Redfish API server. Possible values are http, https
   #
   protocol: https
@@ -503,7 +513,7 @@ Once a file with the above config has been placed and secured, say at `/etc/ceem
 the collector can be enabled and configured as follows:
 
 ```bash
-ceems_exporter --collector.redfish --collector.redfish.web-config=/etc/ceems_exporter/redfish-config.yml
+ceems_exporter --collector.redfish --collector.redfish.web-config-file=/etc/ceems_exporter/redfish-config.yml
 ```
 
 This configuration assumes that the Redfish API server is reachable from the compute node
@@ -522,10 +532,17 @@ as the `external_url` in the Redfish web config of the collector.
 The Redfish proxy uses a very simple config file that is optional. A sample configuration
 file is shown below:
 
+:::warning[WARNING]
+
+The configuration file for Redfish proxy must now be provided under `redfish_proxy` section
+rather than `redfish_config` section which has been deprecated.
+
+:::
+
 ```yaml
 ---
 # Configuration file for redfish_proxy app
-redfish_config:
+redfish_proxy:
   # This section must provide web configuration of
   # Redfish API server.
   #
@@ -599,7 +616,7 @@ This will start the Redfish proxy on the management node running at `mgmt-0:5000
 Redfish configuration file for the exporter should be set as follows:
 
 ```yaml
-redfish_web_config:
+redfish_web:
   # Redfish API server config
   protocol: http
   hostname: '{hostname}-bmc'

--- a/website/docs/configuration/config-reference.md
+++ b/website/docs/configuration/config-reference.md
@@ -642,14 +642,12 @@ configuration file can be found in the
 #
 ---
 ceems_lb:
-  # Load balancing strategy. Three possibilities:
+  # Load balancing strategy. Two possibilities:
   #
   # - round-robin
   # - least-connection
   #
   # Round robin and least connection are classic strategies.
-  # Resource-based works based on the query range in the TSDB query. The 
-  # query will be proxied to the backend that covers the query_range.
   #
   [ strategy: <lbstrategy> | default = round-robin ]
 

--- a/website/docs/installation/build.md
+++ b/website/docs/installation/build.md
@@ -34,7 +34,7 @@ The CEEMS API server and CEEMS load balancer use SQLite and hence require CGO fo
 To build these two components, execute:
 
 ```bash
-CGO_BUILD=1 make build
+CGO_APPS=1 make build
 ```
 
 This will build the `ceems_api_server` and `ceems_lb` binaries in the `./bin` folder.


### PR DESCRIPTION
* Rename redfish_web_config to redfish_web for redfish collector

* Rename redfish_config to redfish_proxy for redfish_proxy app

* Add deprecated logs to all the modified configs so that we let users to change

* Rename CGO_BUILD to CGO_APPS in makefile which is more intutive. Update CI workflows with new var.

* Update docs accordingly