### PR TITLE
Make multiple update calls to eBPF coll in unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,7 @@
 coverage.txt
 
 # Output of the go coverage tool, specifically when used with LiteIDE
-*.out
-*.out.tmp
+coverage*
 
 # Dependency directories (remove the comment below to include it)
 vendor/

--- a/Makefile
+++ b/Makefile
@@ -121,10 +121,13 @@ all:: vet common-all $(checkbpf) $(cross-test) $(test-docker) $(checkmetrics) $(
 
 .PHONY: coverage
 coverage:
-	@echo ">> getting coverage report"
-	tail -n +2 coverage-cgo.out > coverage-cgo.tmp.out && mv coverage-cgo.tmp.out coverage-cgo.out
-	cat coverage-go.out coverage-cgo.out > coverage.out
-	$(GO) tool cover -func=coverage.out -o=coverage.out
+	@echo ">> getting coverage reports"
+	$(GO) tool cover -html=coverage-go.out -o coverage-go.html
+	$(GO) tool cover -html=coverage-cgo.out -o coverage-cgo.html
+	cp coverage-go.out coverage-raw.out
+	tail -n +2 coverage-cgo.out >> coverage-raw.out
+	$(GO) tool cover -html=coverage-raw.out -o coverage.html
+	$(GO) tool cover -func=coverage-raw.out -o=coverage.out
 
 .PHONY: test
 test: pkg/collector/testdata/sys/.unpacked pkg/collector/testdata/proc/.unpacked bpf

--- a/pkg/collector/ebpf_test.go
+++ b/pkg/collector/ebpf_test.go
@@ -5,6 +5,7 @@ import (
 	"os/user"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
@@ -183,8 +184,15 @@ func TestNewEbpfCollector(t *testing.T) {
 		}
 	}()
 
-	err = collector.Update(metrics, nil, "")
-	require.NoError(t, err)
+	// Make multiple update calls to make sure
+	// we cover most of the code as eBPF maps
+	// might not be populated with just one call
+	for range 5 {
+		err = collector.Update(metrics, nil, "")
+		require.NoError(t, err)
+
+		time.Sleep(2 * time.Second)
+	}
 
 	err = collector.Stop(t.Context())
 	require.NoError(t, err)


### PR DESCRIPTION
* Making a single update might not cover most of the code as maps population can be runtime dependent. This influences the coverage and depending on run, we get different coverages. So, we make multiple update calls so that coverage is expected to be more reproducible. However, there is no guarantee!

* Create HTML coverage reports with coverage target in makefile. Useful for comparisons