### PR TITLE
chore: Make lack of RAPL power limit error logs debug

### DIFF
--- a/pkg/collector/perf_test.go
+++ b/pkg/collector/perf_test.go
@@ -185,6 +185,9 @@ func TestNewProfilers(t *testing.T) {
 	pids := collector.newProfilers(cgroups)
 	assert.ElementsMatch(t, pids, []int{os.Getpid()})
 
+	// Update state maps
+	collector.updateStateMaps(pids, []string{"1234"})
+
 	// update counters
 	err = collector.updateHardwareCounters("1234", []procfs.Proc{{PID: os.Getpid()}}, metrics)
 	require.NoError(t, err)

--- a/pkg/collector/rapl.go
+++ b/pkg/collector/rapl.go
@@ -152,7 +152,8 @@ func (c *raplCollector) Update(ch chan<- prometheus.Metric) error {
 	wg.Go(func() {
 		err := c.updateLimits(zones, ch)
 		if err != nil {
-			c.logger.Error("Failed to update RAPL power limits", "err", err)
+			// Totally fine not to have power limit files. Stop spamming logs
+			c.logger.Debug("Failed to update RAPL power limits", "err", err)
 		}
 	})
 


### PR DESCRIPTION
* To reduce spamming logs as not having power limit files is very normal on some hardware.

* Fix minor unit test failing for perf collector.

Fixes #510  