### PR TITLE
fix: Ensure users and projects are replaced correctly in DB

### DIFF
--- a/pkg/api/db/db.go
+++ b/pkg/api/db/db.go
@@ -795,6 +795,7 @@ func (s *stats) execStatements(
 				sql.Named(base.UsersDBTableStructFieldColNameMap["Projects"], user.Projects),
 				sql.Named(base.UsersDBTableStructFieldColNameMap["Tags"], user.Tags),
 				sql.Named(base.UsersDBTableStructFieldColNameMap["LastUpdatedAt"], user.LastUpdatedAt),
+				sql.Named("replace_projects", !cluster.Append),
 			)
 			if err != nil {
 				s.logger.Error("Failed to insert user in DB", "cluster_id", cluster.Cluster.ID, "user", user.Name, "err", err)
@@ -814,6 +815,7 @@ func (s *stats) execStatements(
 				sql.Named(base.ProjectsDBTableStructFieldColNameMap["Users"], project.Users),
 				sql.Named(base.ProjectsDBTableStructFieldColNameMap["Tags"], project.Tags),
 				sql.Named(base.ProjectsDBTableStructFieldColNameMap["LastUpdatedAt"], project.LastUpdatedAt),
+				sql.Named("replace_users", !cluster.Append),
 			)
 			if err != nil {
 				s.logger.Error("Failed to insert project in DB", "cluster_id", cluster.Cluster.ID, "project", project.Name, "err", err)

--- a/pkg/api/db/statements/projects.sql
+++ b/pkg/api/db/statements/projects.sql
@@ -3,6 +3,6 @@ INSERT INTO projects (uid,cluster_id,resource_manager,name,users,tags,last_updat
   cluster_id = :cluster_id,
   resource_manager = :resource_manager,
   name = :name,
-  users = merge_list(users, :users, false),
+  users = merge_list(users, :users, :replace_users),
   tags = :tags,
   last_updated_at = :last_updated_at  

--- a/pkg/api/db/statements/users.sql
+++ b/pkg/api/db/statements/users.sql
@@ -3,6 +3,6 @@ INSERT INTO users (uid,cluster_id,resource_manager,name,projects,tags,last_updat
   cluster_id = :cluster_id,
   resource_manager = :resource_manager,
   name = :name,
-  projects = merge_list(projects, :projects, false),
+  projects = merge_list(projects, :projects, :replace_projects),
   tags = :tags,
   last_updated_at = :last_updated_at 

--- a/pkg/api/models/types.go
+++ b/pkg/api/models/types.go
@@ -404,10 +404,12 @@ type ClusterUnits struct {
 type ClusterProjects struct {
 	Cluster  Cluster
 	Projects []Project
+	Append   bool // Append to the existing list
 }
 
 // ClusterUsers is the container for the users for a given cluster.
 type ClusterUsers struct {
 	Cluster Cluster
 	Users   []User
+	Append  bool // Append to the existing list
 }

--- a/pkg/api/resource/lsf/manager.go
+++ b/pkg/api/resource/lsf/manager.go
@@ -116,9 +116,9 @@ func (s *lsfScheduler) FetchUsersProjects(
 		s.logger.Info("LSF user account data fetched", "cluster_id", s.cluster.ID, "num_users", len(users), "num_accounts", len(projects))
 
 		return []models.ClusterUsers{
-				{Cluster: s.cluster, Users: users},
+				{Cluster: s.cluster, Users: users, Append: true},
 			}, []models.ClusterProjects{
-				{Cluster: s.cluster, Projects: projects},
+				{Cluster: s.cluster, Projects: projects, Append: true},
 			}, nil
 	}
 


### PR DESCRIPTION
* For resource managers like SLURM, we can get user account associations for each update. In this case, we need to replace existing DB entries at each update. The last refactoring we made to add support for LSF, we were merging the list of users and projects by default which is wrong for SLURM. This commit passes an additional SQL named argument `replace` that decides whether to append or replace list in DB.